### PR TITLE
feat(worlds): schema migrations for the worlds feature (W1)

### DIFF
--- a/src/types/supabase-generated.type.ts
+++ b/src/types/supabase-generated.type.ts
@@ -430,6 +430,7 @@ export type Database = {
           playset: Json
           rulesets: Json
           special_track_values: Json
+          world_id: string | null
         }
         Insert: {
           color_scheme?: string | null
@@ -442,6 +443,7 @@ export type Database = {
           playset?: Json
           rulesets?: Json
           special_track_values?: Json
+          world_id?: string | null
         }
         Update: {
           color_scheme?: string | null
@@ -454,8 +456,17 @@ export type Database = {
           playset?: Json
           rulesets?: Json
           special_track_values?: Json
+          world_id?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "games_world_id_fkey"
+            columns: ["world_id"]
+            isOneToOne: false
+            referencedRelation: "worlds"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       note_folders: {
         Row: {
@@ -600,12 +611,303 @@ export type Database = {
         }
         Relationships: []
       }
+      world_categories: {
+        Row: {
+          created_at: string
+          field_definitions: Json
+          icon: Json | null
+          id: string
+          name: string
+          sort_order: number
+          supports_bonds: boolean
+          supports_hierarchy: boolean
+          supports_map: boolean
+          updated_at: string
+          world_id: string
+        }
+        Insert: {
+          created_at?: string
+          field_definitions?: Json
+          icon?: Json | null
+          id?: string
+          name: string
+          sort_order?: number
+          supports_bonds?: boolean
+          supports_hierarchy?: boolean
+          supports_map?: boolean
+          updated_at?: string
+          world_id: string
+        }
+        Update: {
+          created_at?: string
+          field_definitions?: Json
+          icon?: Json | null
+          id?: string
+          name?: string
+          sort_order?: number
+          supports_bonds?: boolean
+          supports_hierarchy?: boolean
+          supports_map?: boolean
+          updated_at?: string
+          world_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "world_categories_world_id_fkey"
+            columns: ["world_id"]
+            isOneToOne: false
+            referencedRelation: "worlds"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      world_entries: {
+        Row: {
+          author_id: string
+          category_id: string
+          created_at: string
+          edit_permissions: Database["public"]["Enums"]["note_edit_permissions"]
+          fields: Json
+          icon: Json | null
+          id: string
+          image_filenames: string[]
+          map: Json | null
+          map_background_filename: string | null
+          map_settings: Json | null
+          name: string
+          notes_content: string | null
+          parent_entry_id: string | null
+          read_permissions: Database["public"]["Enums"]["note_read_permissions"]
+          updated_at: string
+          world_id: string
+        }
+        Insert: {
+          author_id: string
+          category_id: string
+          created_at?: string
+          edit_permissions?: Database["public"]["Enums"]["note_edit_permissions"]
+          fields?: Json
+          icon?: Json | null
+          id?: string
+          image_filenames?: string[]
+          map?: Json | null
+          map_background_filename?: string | null
+          map_settings?: Json | null
+          name: string
+          notes_content?: string | null
+          parent_entry_id?: string | null
+          read_permissions?: Database["public"]["Enums"]["note_read_permissions"]
+          updated_at?: string
+          world_id: string
+        }
+        Update: {
+          author_id?: string
+          category_id?: string
+          created_at?: string
+          edit_permissions?: Database["public"]["Enums"]["note_edit_permissions"]
+          fields?: Json
+          icon?: Json | null
+          id?: string
+          image_filenames?: string[]
+          map?: Json | null
+          map_background_filename?: string | null
+          map_settings?: Json | null
+          name?: string
+          notes_content?: string | null
+          parent_entry_id?: string | null
+          read_permissions?: Database["public"]["Enums"]["note_read_permissions"]
+          updated_at?: string
+          world_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "world_entries_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "world_entries_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "world_categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "world_entries_parent_entry_id_fkey"
+            columns: ["parent_entry_id"]
+            isOneToOne: false
+            referencedRelation: "world_entries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "world_entries_world_id_fkey"
+            columns: ["world_id"]
+            isOneToOne: false
+            referencedRelation: "worlds"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      world_entry_bonds: {
+        Row: {
+          character_id: string
+          created_at: string
+          entry_id: string
+        }
+        Insert: {
+          character_id: string
+          created_at?: string
+          entry_id: string
+        }
+        Update: {
+          character_id?: string
+          created_at?: string
+          entry_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "world_entry_bonds_character_id_fkey"
+            columns: ["character_id"]
+            isOneToOne: false
+            referencedRelation: "characters"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "world_entry_bonds_entry_id_fkey"
+            columns: ["entry_id"]
+            isOneToOne: false
+            referencedRelation: "world_entries"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      world_entry_gm_data: {
+        Row: {
+          created_at: string
+          entry_id: string
+          fields: Json
+          gm_notes_content: string | null
+          updated_at: string
+          world_id: string
+        }
+        Insert: {
+          created_at?: string
+          entry_id: string
+          fields?: Json
+          gm_notes_content?: string | null
+          updated_at?: string
+          world_id: string
+        }
+        Update: {
+          created_at?: string
+          entry_id?: string
+          fields?: Json
+          gm_notes_content?: string | null
+          updated_at?: string
+          world_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "world_entry_gm_data_entry_id_fkey"
+            columns: ["entry_id"]
+            isOneToOne: true
+            referencedRelation: "world_entries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "world_entry_gm_data_world_id_fkey"
+            columns: ["world_id"]
+            isOneToOne: false
+            referencedRelation: "worlds"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      world_players: {
+        Row: {
+          created_at: string
+          role: string
+          user_id: string
+          world_id: string
+        }
+        Insert: {
+          created_at?: string
+          role: string
+          user_id: string
+          world_id: string
+        }
+        Update: {
+          created_at?: string
+          role?: string
+          user_id?: string
+          world_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "world_players_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "world_players_world_id_fkey"
+            columns: ["world_id"]
+            isOneToOne: false
+            referencedRelation: "worlds"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      worlds: {
+        Row: {
+          created_at: string
+          created_by: string
+          description: string | null
+          id: string
+          name: string
+          setting_key: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          description?: string | null
+          id?: string
+          name: string
+          setting_key?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          description?: string | null
+          id?: string
+          name?: string
+          setting_key?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "worlds_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      world_role: {
+        Args: { p_world_id: string; p_uid: string }
+        Returns: string
+      }
     }
     Enums: {
       character_initiative_status:

--- a/supabase/migrations/20260609000000_changes.sql
+++ b/supabase/migrations/20260609000000_changes.sql
@@ -564,7 +564,9 @@ as permissive
 for delete
 to authenticated
 using (
+    -- Owner can remove anyone; any member can remove themselves (leave)
     public.world_role(world_players.world_id, ( select auth.uid() )) = 'owner'
+    or world_players.user_id = ( select auth.uid() )
 );
 
 
@@ -900,6 +902,18 @@ on conflict (id) do nothing;
 
 -- Storage RLS: any authenticated world/game member can read (public bucket already
 -- exposes objects publicly, but explicit policies guard uploads/deletes).
+--
+-- Object path convention for both buckets: <worldId>/<entryId>/<filename>
+-- Write policies enforce world membership via world_role() on the path's first
+-- segment (the worldId). The first segment is validated as a UUID before casting
+-- to avoid errors on malformed paths.
+--
+-- Entry images: players may upload (players can author entries per edit_permissions).
+-- Map backgrounds: owner/editor/guide only (map management is GM/editor territory).
+
+-- UUID guard helper: use CASE WHEN for the UUID validation before casting.
+-- Postgres does NOT guarantee AND short-circuit evaluation in plain SQL expressions,
+-- but DOES guarantee CASE WHEN branches — so the cast only runs when the regex passes.
 
 create policy "World members can upload entry images"
 on storage.objects
@@ -908,17 +922,121 @@ for insert
 to authenticated
 with check (
     bucket_id = 'world_entry_images'
-    and auth.uid() is not null
+    and case when (storage.foldername(name))[1]
+                    ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             then public.world_role(
+                    ((storage.foldername(name))[1])::uuid,
+                    auth.uid()
+                  ) in ('owner', 'editor', 'guide', 'player')
+             else false
+        end
 );
 
-create policy "World members can upload map backgrounds"
+create policy "World members can update entry images"
+on storage.objects
+as permissive
+for update
+to authenticated
+using (
+    bucket_id = 'world_entry_images'
+    and case when (storage.foldername(name))[1]
+                    ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             then public.world_role(
+                    ((storage.foldername(name))[1])::uuid,
+                    auth.uid()
+                  ) in ('owner', 'editor', 'guide', 'player')
+             else false
+        end
+)
+with check (
+    bucket_id = 'world_entry_images'
+    and case when (storage.foldername(name))[1]
+                    ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             then public.world_role(
+                    ((storage.foldername(name))[1])::uuid,
+                    auth.uid()
+                  ) in ('owner', 'editor', 'guide', 'player')
+             else false
+        end
+);
+
+create policy "World members can delete entry images"
+on storage.objects
+as permissive
+for delete
+to authenticated
+using (
+    bucket_id = 'world_entry_images'
+    and case when (storage.foldername(name))[1]
+                    ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             then public.world_role(
+                    ((storage.foldername(name))[1])::uuid,
+                    auth.uid()
+                  ) in ('owner', 'editor', 'guide', 'player')
+             else false
+        end
+);
+
+create policy "GMs and editors can upload map backgrounds"
 on storage.objects
 as permissive
 for insert
 to authenticated
 with check (
     bucket_id = 'world_map_backgrounds'
-    and auth.uid() is not null
+    and case when (storage.foldername(name))[1]
+                    ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             then public.world_role(
+                    ((storage.foldername(name))[1])::uuid,
+                    auth.uid()
+                  ) in ('owner', 'editor', 'guide')
+             else false
+        end
+);
+
+create policy "GMs and editors can update map backgrounds"
+on storage.objects
+as permissive
+for update
+to authenticated
+using (
+    bucket_id = 'world_map_backgrounds'
+    and case when (storage.foldername(name))[1]
+                    ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             then public.world_role(
+                    ((storage.foldername(name))[1])::uuid,
+                    auth.uid()
+                  ) in ('owner', 'editor', 'guide')
+             else false
+        end
+)
+with check (
+    bucket_id = 'world_map_backgrounds'
+    and case when (storage.foldername(name))[1]
+                    ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             then public.world_role(
+                    ((storage.foldername(name))[1])::uuid,
+                    auth.uid()
+                  ) in ('owner', 'editor', 'guide')
+             else false
+        end
+);
+
+create policy "GMs and editors can delete map backgrounds"
+on storage.objects
+as permissive
+for delete
+to authenticated
+using (
+    bucket_id = 'world_map_backgrounds'
+    and case when (storage.foldername(name))[1]
+                    ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+             then public.world_role(
+                    ((storage.foldername(name))[1])::uuid,
+                    auth.uid()
+                  ) in ('owner', 'editor', 'guide')
+             else false
+        end
 );
 
 create policy "World entry images are publicly readable"
@@ -934,23 +1052,3 @@ as permissive
 for select
 to public
 using ( bucket_id = 'world_map_backgrounds' );
-
-create policy "Authenticated users can delete world entry images"
-on storage.objects
-as permissive
-for delete
-to authenticated
-using (
-    bucket_id = 'world_entry_images'
-    and owner = ( select auth.uid() )
-);
-
-create policy "Authenticated users can delete world map backgrounds"
-on storage.objects
-as permissive
-for delete
-to authenticated
-using (
-    bucket_id = 'world_map_backgrounds'
-    and owner = ( select auth.uid() )
-);

--- a/supabase/migrations/20260609000000_changes.sql
+++ b/supabase/migrations/20260609000000_changes.sql
@@ -1,0 +1,956 @@
+-- =============================================================================
+-- Worlds schema (task W1)
+-- Implements: worlds, world_players, world_categories, world_entries,
+--             world_entry_gm_data, world_entry_bonds
+--             + games.world_id FK
+--             + storage buckets for entry images and map backgrounds
+--             + world_role() helper function
+--             + RLS policies
+--             + realtime publication additions
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Core tables
+-- ---------------------------------------------------------------------------
+
+create table "public"."worlds" (
+    "id"          uuid not null default gen_random_uuid(),
+    "name"        text not null,
+    "description" text,
+    "created_by"  uuid not null,
+    "setting_key" text,
+    "created_at"  timestamp with time zone not null default now(),
+    "updated_at"  timestamp with time zone not null default now()
+);
+
+alter table "public"."worlds" enable row level security;
+
+CREATE UNIQUE INDEX worlds_pkey ON public.worlds USING btree (id);
+
+alter table "public"."worlds" add constraint "worlds_pkey" PRIMARY KEY using index "worlds_pkey";
+
+alter table "public"."worlds" add constraint "worlds_created_by_fkey"
+    FOREIGN KEY (created_by) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."worlds" validate constraint "worlds_created_by_fkey";
+
+
+-- ---------------------------------------------------------------------------
+-- 2. world_players  (explicit membership + role)
+-- ---------------------------------------------------------------------------
+
+create table "public"."world_players" (
+    "world_id" uuid not null,
+    "user_id"  uuid not null,
+    "role"     text not null,
+    "created_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."world_players" enable row level security;
+
+CREATE UNIQUE INDEX world_players_pkey ON public.world_players USING btree (world_id, user_id);
+
+alter table "public"."world_players" add constraint "world_players_pkey" PRIMARY KEY using index "world_players_pkey";
+
+alter table "public"."world_players" add constraint "world_players_role_check"
+    check (role in ('owner', 'editor', 'viewer'));
+
+alter table "public"."world_players" add constraint "world_players_world_id_fkey"
+    FOREIGN KEY (world_id) REFERENCES worlds(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_players" validate constraint "world_players_world_id_fkey";
+
+alter table "public"."world_players" add constraint "world_players_user_id_fkey"
+    FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_players" validate constraint "world_players_user_id_fkey";
+
+
+-- ---------------------------------------------------------------------------
+-- 3. games.world_id FK  (one world per game, many games per world)
+-- ---------------------------------------------------------------------------
+
+alter table "public"."games" add column "world_id" uuid null;
+
+alter table "public"."games" add constraint "games_world_id_fkey"
+    FOREIGN KEY (world_id) REFERENCES worlds(id) ON UPDATE CASCADE ON DELETE SET NULL not valid;
+alter table "public"."games" validate constraint "games_world_id_fkey";
+
+
+-- ---------------------------------------------------------------------------
+-- 4. world_categories
+-- ---------------------------------------------------------------------------
+
+create table "public"."world_categories" (
+    "id"                 uuid not null default gen_random_uuid(),
+    "world_id"           uuid not null,
+    "name"               text not null,
+    "icon"               jsonb,
+    "sort_order"         integer not null default 0,
+    "supports_hierarchy" boolean not null default false,
+    "supports_map"       boolean not null default false,
+    "supports_bonds"     boolean not null default false,
+    "field_definitions"  jsonb not null default '[]'::jsonb,
+    "created_at"         timestamp with time zone not null default now(),
+    "updated_at"         timestamp with time zone not null default now()
+);
+
+alter table "public"."world_categories" enable row level security;
+
+CREATE UNIQUE INDEX world_categories_pkey ON public.world_categories USING btree (id);
+
+alter table "public"."world_categories" add constraint "world_categories_pkey" PRIMARY KEY using index "world_categories_pkey";
+
+alter table "public"."world_categories" add constraint "world_categories_world_id_fkey"
+    FOREIGN KEY (world_id) REFERENCES worlds(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_categories" validate constraint "world_categories_world_id_fkey";
+
+
+-- ---------------------------------------------------------------------------
+-- 5. world_entries
+-- ---------------------------------------------------------------------------
+
+create table "public"."world_entries" (
+    "id"                    uuid not null default gen_random_uuid(),
+    "world_id"              uuid not null,
+    "category_id"           uuid not null,
+    "parent_entry_id"       uuid null,
+    "name"                  text not null,
+    "icon"                  jsonb,
+    "image_filenames"       text[] not null default '{}'::text[],
+    "fields"                jsonb not null default '{}'::jsonb,
+    "notes_content"         bytea,
+    "map"                   jsonb,
+    "map_background_filename" text,
+    "map_settings"          jsonb,
+    "read_permissions"      note_read_permissions not null default 'all_players'::note_read_permissions,
+    "edit_permissions"      note_edit_permissions not null default 'all_players'::note_edit_permissions,
+    "author_id"             uuid not null,
+    "created_at"            timestamp with time zone not null default now(),
+    "updated_at"            timestamp with time zone not null default now()
+);
+
+alter table "public"."world_entries" enable row level security;
+
+CREATE UNIQUE INDEX world_entries_pkey ON public.world_entries USING btree (id);
+
+alter table "public"."world_entries" add constraint "world_entries_pkey" PRIMARY KEY using index "world_entries_pkey";
+
+alter table "public"."world_entries" add constraint "world_entries_world_id_fkey"
+    FOREIGN KEY (world_id) REFERENCES worlds(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_entries" validate constraint "world_entries_world_id_fkey";
+
+alter table "public"."world_entries" add constraint "world_entries_category_id_fkey"
+    FOREIGN KEY (category_id) REFERENCES world_categories(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_entries" validate constraint "world_entries_category_id_fkey";
+
+alter table "public"."world_entries" add constraint "world_entries_parent_entry_id_fkey"
+    FOREIGN KEY (parent_entry_id) REFERENCES world_entries(id) ON UPDATE CASCADE ON DELETE SET NULL not valid;
+alter table "public"."world_entries" validate constraint "world_entries_parent_entry_id_fkey";
+
+alter table "public"."world_entries" add constraint "world_entries_author_id_fkey"
+    FOREIGN KEY (author_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_entries" validate constraint "world_entries_author_id_fkey";
+
+
+-- ---------------------------------------------------------------------------
+-- 6. world_entry_gm_data  (GM-only values, separate row for RLS)
+-- ---------------------------------------------------------------------------
+
+create table "public"."world_entry_gm_data" (
+    "entry_id"          uuid not null,
+    "world_id"          uuid not null,
+    "fields"            jsonb not null default '{}'::jsonb,
+    "gm_notes_content"  bytea,
+    "created_at"        timestamp with time zone not null default now(),
+    "updated_at"        timestamp with time zone not null default now()
+);
+
+alter table "public"."world_entry_gm_data" enable row level security;
+
+CREATE UNIQUE INDEX world_entry_gm_data_pkey ON public.world_entry_gm_data USING btree (entry_id);
+
+alter table "public"."world_entry_gm_data" add constraint "world_entry_gm_data_pkey" PRIMARY KEY using index "world_entry_gm_data_pkey";
+
+alter table "public"."world_entry_gm_data" add constraint "world_entry_gm_data_entry_id_fkey"
+    FOREIGN KEY (entry_id) REFERENCES world_entries(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_entry_gm_data" validate constraint "world_entry_gm_data_entry_id_fkey";
+
+alter table "public"."world_entry_gm_data" add constraint "world_entry_gm_data_world_id_fkey"
+    FOREIGN KEY (world_id) REFERENCES worlds(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_entry_gm_data" validate constraint "world_entry_gm_data_world_id_fkey";
+
+
+-- ---------------------------------------------------------------------------
+-- 7. world_entry_bonds  (character ↔ entry bond records)
+-- ---------------------------------------------------------------------------
+
+create table "public"."world_entry_bonds" (
+    "entry_id"     uuid not null,
+    "character_id" uuid not null,
+    "created_at"   timestamp with time zone not null default now()
+);
+
+alter table "public"."world_entry_bonds" enable row level security;
+
+CREATE UNIQUE INDEX world_entry_bonds_pkey ON public.world_entry_bonds USING btree (entry_id, character_id);
+
+alter table "public"."world_entry_bonds" add constraint "world_entry_bonds_pkey" PRIMARY KEY using index "world_entry_bonds_pkey";
+
+alter table "public"."world_entry_bonds" add constraint "world_entry_bonds_entry_id_fkey"
+    FOREIGN KEY (entry_id) REFERENCES world_entries(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_entry_bonds" validate constraint "world_entry_bonds_entry_id_fkey";
+
+alter table "public"."world_entry_bonds" add constraint "world_entry_bonds_character_id_fkey"
+    FOREIGN KEY (character_id) REFERENCES characters(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+alter table "public"."world_entry_bonds" validate constraint "world_entry_bonds_character_id_fkey";
+
+
+-- ---------------------------------------------------------------------------
+-- 8. Indexes
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX worlds_created_by_idx ON public.worlds USING btree (created_by);
+
+CREATE INDEX world_players_world_id_idx ON public.world_players USING btree (world_id);
+CREATE INDEX world_players_user_id_idx  ON public.world_players USING btree (user_id);
+
+CREATE INDEX games_world_id_idx ON public.games USING btree (world_id);
+
+CREATE INDEX world_categories_world_id_idx ON public.world_categories USING btree (world_id);
+
+CREATE INDEX world_entries_world_id_idx         ON public.world_entries USING btree (world_id);
+CREATE INDEX world_entries_category_id_idx      ON public.world_entries USING btree (category_id);
+CREATE INDEX world_entries_parent_entry_id_idx  ON public.world_entries USING btree (parent_entry_id);
+CREATE INDEX world_entries_author_id_idx        ON public.world_entries USING btree (author_id);
+CREATE INDEX world_entries_world_id_read_permissions_idx
+    ON public.world_entries USING btree (world_id, read_permissions);
+
+CREATE INDEX world_entry_gm_data_world_id_idx ON public.world_entry_gm_data USING btree (world_id);
+
+CREATE INDEX world_entry_bonds_entry_id_idx     ON public.world_entry_bonds USING btree (entry_id);
+CREATE INDEX world_entry_bonds_character_id_idx ON public.world_entry_bonds USING btree (character_id);
+
+
+-- ---------------------------------------------------------------------------
+-- 9. updated_at triggers  (mirror notes pattern — no moddatetime extension
+--    is used in this project, so we add a small trigger function inline)
+-- ---------------------------------------------------------------------------
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$function$;
+
+CREATE TRIGGER worlds_set_updated_at
+    BEFORE UPDATE ON public.worlds
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER world_categories_set_updated_at
+    BEFORE UPDATE ON public.world_categories
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER world_entries_set_updated_at
+    BEFORE UPDATE ON public.world_entries
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER world_entry_gm_data_set_updated_at
+    BEFORE UPDATE ON public.world_entry_gm_data
+    FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+-- ---------------------------------------------------------------------------
+-- 10. world_role() helper function
+--     Returns: 'owner' | 'editor' | 'guide' | 'player' | 'none'
+--     Derived from world_players (explicit) and game_players via linked games.
+--     Guides (game role 'guide') map to GM-equivalent access.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.world_role(p_world_id uuid, p_uid uuid)
+ RETURNS text
+ LANGUAGE sql
+ STABLE
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+    SELECT coalesce(
+        -- Explicit world membership takes precedence
+        (SELECT wp.role
+         FROM public.world_players wp
+         WHERE wp.world_id = p_world_id
+           AND wp.user_id  = p_uid
+         LIMIT 1),
+        -- Derive role from best game_players role across linked games
+        (SELECT
+            CASE gp.role
+                WHEN 'guide'  THEN 'guide'
+                WHEN 'player' THEN 'player'
+                ELSE 'player'
+            END
+         FROM public.game_players gp
+         JOIN public.games g ON g.id = gp.game_id
+         WHERE g.world_id   = p_world_id
+           AND gp.user_id   = p_uid
+         ORDER BY
+             -- guides outrank players when a user has both roles across games
+             CASE gp.role WHEN 'guide' THEN 0 ELSE 1 END
+         LIMIT 1),
+        'none'
+    );
+$function$;
+
+
+-- ---------------------------------------------------------------------------
+-- 11. Grants
+-- ---------------------------------------------------------------------------
+
+grant delete on table "public"."worlds" to "anon";
+grant insert on table "public"."worlds" to "anon";
+grant references on table "public"."worlds" to "anon";
+grant select on table "public"."worlds" to "anon";
+grant trigger on table "public"."worlds" to "anon";
+grant truncate on table "public"."worlds" to "anon";
+grant update on table "public"."worlds" to "anon";
+
+grant delete on table "public"."worlds" to "authenticated";
+grant insert on table "public"."worlds" to "authenticated";
+grant references on table "public"."worlds" to "authenticated";
+grant select on table "public"."worlds" to "authenticated";
+grant trigger on table "public"."worlds" to "authenticated";
+grant truncate on table "public"."worlds" to "authenticated";
+grant update on table "public"."worlds" to "authenticated";
+
+grant delete on table "public"."worlds" to "service_role";
+grant insert on table "public"."worlds" to "service_role";
+grant references on table "public"."worlds" to "service_role";
+grant select on table "public"."worlds" to "service_role";
+grant trigger on table "public"."worlds" to "service_role";
+grant truncate on table "public"."worlds" to "service_role";
+grant update on table "public"."worlds" to "service_role";
+
+grant delete on table "public"."world_players" to "anon";
+grant insert on table "public"."world_players" to "anon";
+grant references on table "public"."world_players" to "anon";
+grant select on table "public"."world_players" to "anon";
+grant trigger on table "public"."world_players" to "anon";
+grant truncate on table "public"."world_players" to "anon";
+grant update on table "public"."world_players" to "anon";
+
+grant delete on table "public"."world_players" to "authenticated";
+grant insert on table "public"."world_players" to "authenticated";
+grant references on table "public"."world_players" to "authenticated";
+grant select on table "public"."world_players" to "authenticated";
+grant trigger on table "public"."world_players" to "authenticated";
+grant truncate on table "public"."world_players" to "authenticated";
+grant update on table "public"."world_players" to "authenticated";
+
+grant delete on table "public"."world_players" to "service_role";
+grant insert on table "public"."world_players" to "service_role";
+grant references on table "public"."world_players" to "service_role";
+grant select on table "public"."world_players" to "service_role";
+grant trigger on table "public"."world_players" to "service_role";
+grant truncate on table "public"."world_players" to "service_role";
+grant update on table "public"."world_players" to "service_role";
+
+grant delete on table "public"."world_categories" to "anon";
+grant insert on table "public"."world_categories" to "anon";
+grant references on table "public"."world_categories" to "anon";
+grant select on table "public"."world_categories" to "anon";
+grant trigger on table "public"."world_categories" to "anon";
+grant truncate on table "public"."world_categories" to "anon";
+grant update on table "public"."world_categories" to "anon";
+
+grant delete on table "public"."world_categories" to "authenticated";
+grant insert on table "public"."world_categories" to "authenticated";
+grant references on table "public"."world_categories" to "authenticated";
+grant select on table "public"."world_categories" to "authenticated";
+grant trigger on table "public"."world_categories" to "authenticated";
+grant truncate on table "public"."world_categories" to "authenticated";
+grant update on table "public"."world_categories" to "authenticated";
+
+grant delete on table "public"."world_categories" to "service_role";
+grant insert on table "public"."world_categories" to "service_role";
+grant references on table "public"."world_categories" to "service_role";
+grant select on table "public"."world_categories" to "service_role";
+grant trigger on table "public"."world_categories" to "service_role";
+grant truncate on table "public"."world_categories" to "service_role";
+grant update on table "public"."world_categories" to "service_role";
+
+grant delete on table "public"."world_entries" to "anon";
+grant insert on table "public"."world_entries" to "anon";
+grant references on table "public"."world_entries" to "anon";
+grant select on table "public"."world_entries" to "anon";
+grant trigger on table "public"."world_entries" to "anon";
+grant truncate on table "public"."world_entries" to "anon";
+grant update on table "public"."world_entries" to "anon";
+
+grant delete on table "public"."world_entries" to "authenticated";
+grant insert on table "public"."world_entries" to "authenticated";
+grant references on table "public"."world_entries" to "authenticated";
+grant select on table "public"."world_entries" to "authenticated";
+grant trigger on table "public"."world_entries" to "authenticated";
+grant truncate on table "public"."world_entries" to "authenticated";
+grant update on table "public"."world_entries" to "authenticated";
+
+grant delete on table "public"."world_entries" to "service_role";
+grant insert on table "public"."world_entries" to "service_role";
+grant references on table "public"."world_entries" to "service_role";
+grant select on table "public"."world_entries" to "service_role";
+grant trigger on table "public"."world_entries" to "service_role";
+grant truncate on table "public"."world_entries" to "service_role";
+grant update on table "public"."world_entries" to "service_role";
+
+grant delete on table "public"."world_entry_gm_data" to "anon";
+grant insert on table "public"."world_entry_gm_data" to "anon";
+grant references on table "public"."world_entry_gm_data" to "anon";
+grant select on table "public"."world_entry_gm_data" to "anon";
+grant trigger on table "public"."world_entry_gm_data" to "anon";
+grant truncate on table "public"."world_entry_gm_data" to "anon";
+grant update on table "public"."world_entry_gm_data" to "anon";
+
+grant delete on table "public"."world_entry_gm_data" to "authenticated";
+grant insert on table "public"."world_entry_gm_data" to "authenticated";
+grant references on table "public"."world_entry_gm_data" to "authenticated";
+grant select on table "public"."world_entry_gm_data" to "authenticated";
+grant trigger on table "public"."world_entry_gm_data" to "authenticated";
+grant truncate on table "public"."world_entry_gm_data" to "authenticated";
+grant update on table "public"."world_entry_gm_data" to "authenticated";
+
+grant delete on table "public"."world_entry_gm_data" to "service_role";
+grant insert on table "public"."world_entry_gm_data" to "service_role";
+grant references on table "public"."world_entry_gm_data" to "service_role";
+grant select on table "public"."world_entry_gm_data" to "service_role";
+grant trigger on table "public"."world_entry_gm_data" to "service_role";
+grant truncate on table "public"."world_entry_gm_data" to "service_role";
+grant update on table "public"."world_entry_gm_data" to "service_role";
+
+grant delete on table "public"."world_entry_bonds" to "anon";
+grant insert on table "public"."world_entry_bonds" to "anon";
+grant references on table "public"."world_entry_bonds" to "anon";
+grant select on table "public"."world_entry_bonds" to "anon";
+grant trigger on table "public"."world_entry_bonds" to "anon";
+grant truncate on table "public"."world_entry_bonds" to "anon";
+grant update on table "public"."world_entry_bonds" to "anon";
+
+grant delete on table "public"."world_entry_bonds" to "authenticated";
+grant insert on table "public"."world_entry_bonds" to "authenticated";
+grant references on table "public"."world_entry_bonds" to "authenticated";
+grant select on table "public"."world_entry_bonds" to "authenticated";
+grant trigger on table "public"."world_entry_bonds" to "authenticated";
+grant truncate on table "public"."world_entry_bonds" to "authenticated";
+grant update on table "public"."world_entry_bonds" to "authenticated";
+
+grant delete on table "public"."world_entry_bonds" to "service_role";
+grant insert on table "public"."world_entry_bonds" to "service_role";
+grant references on table "public"."world_entry_bonds" to "service_role";
+grant select on table "public"."world_entry_bonds" to "service_role";
+grant trigger on table "public"."world_entry_bonds" to "service_role";
+grant truncate on table "public"."world_entry_bonds" to "service_role";
+grant update on table "public"."world_entry_bonds" to "service_role";
+
+grant execute on function public.world_role(uuid, uuid) to authenticated;
+grant execute on function public.world_role(uuid, uuid) to service_role;
+
+
+-- ---------------------------------------------------------------------------
+-- 12. RLS Policies
+-- ---------------------------------------------------------------------------
+
+-- ---- worlds ---------------------------------------------------------------
+
+-- Read: explicit world_players member OR player in any linked game
+create policy "World members and linked game players can read worlds"
+on "public"."worlds"
+as permissive
+for select
+to authenticated
+using (
+    exists (
+        select 1 from public.world_players wp
+        where wp.world_id = worlds.id
+          and wp.user_id  = ( select auth.uid() )
+    )
+    or exists (
+        select 1 from public.game_players gp
+        join public.games g on g.id = gp.game_id
+        where g.world_id  = worlds.id
+          and gp.user_id  = ( select auth.uid() )
+    )
+);
+
+-- Insert: any authenticated user can create a world (they become owner via app logic)
+create policy "Authenticated users can create worlds"
+on "public"."worlds"
+as permissive
+for insert
+to authenticated
+with check ( created_by = ( select auth.uid() ) );
+
+-- Update: owner or editor
+create policy "World owners and editors can update worlds"
+on "public"."worlds"
+as permissive
+for update
+to authenticated
+using (
+    public.world_role(worlds.id, ( select auth.uid() )) in ('owner', 'editor')
+)
+with check (
+    public.world_role(worlds.id, ( select auth.uid() )) in ('owner', 'editor')
+);
+
+-- Delete: owner only
+create policy "World owners can delete worlds"
+on "public"."worlds"
+as permissive
+for delete
+to authenticated
+using (
+    public.world_role(worlds.id, ( select auth.uid() )) = 'owner'
+);
+
+
+-- ---- world_players --------------------------------------------------------
+
+-- Read: any world member or linked game player can read the membership list
+create policy "World members can read world_players"
+on "public"."world_players"
+as permissive
+for select
+to authenticated
+using (
+    exists (
+        select 1 from public.world_players wp2
+        where wp2.world_id = world_players.world_id
+          and wp2.user_id  = ( select auth.uid() )
+    )
+    or exists (
+        select 1 from public.game_players gp
+        join public.games g on g.id = gp.game_id
+        where g.world_id  = world_players.world_id
+          and gp.user_id  = ( select auth.uid() )
+    )
+);
+
+-- Insert/Update/Delete: owner only
+create policy "World owners can insert world_players"
+on "public"."world_players"
+as permissive
+for insert
+to authenticated
+with check (
+    public.world_role(world_players.world_id, ( select auth.uid() )) = 'owner'
+);
+
+create policy "World owners can update world_players"
+on "public"."world_players"
+as permissive
+for update
+to authenticated
+using (
+    public.world_role(world_players.world_id, ( select auth.uid() )) = 'owner'
+)
+with check (
+    public.world_role(world_players.world_id, ( select auth.uid() )) = 'owner'
+);
+
+create policy "World owners can delete world_players"
+on "public"."world_players"
+as permissive
+for delete
+to authenticated
+using (
+    public.world_role(world_players.world_id, ( select auth.uid() )) = 'owner'
+);
+
+
+-- ---- world_categories -----------------------------------------------------
+
+-- Read: any world member or linked game player
+create policy "World members can read world_categories"
+on "public"."world_categories"
+as permissive
+for select
+to authenticated
+using (
+    exists (
+        select 1 from public.world_players wp
+        where wp.world_id = world_categories.world_id
+          and wp.user_id  = ( select auth.uid() )
+    )
+    or exists (
+        select 1 from public.game_players gp
+        join public.games g on g.id = gp.game_id
+        where g.world_id  = world_categories.world_id
+          and gp.user_id  = ( select auth.uid() )
+    )
+);
+
+-- Write: owner or editor
+create policy "World owners and editors can insert world_categories"
+on "public"."world_categories"
+as permissive
+for insert
+to authenticated
+with check (
+    public.world_role(world_categories.world_id, ( select auth.uid() )) in ('owner', 'editor')
+);
+
+create policy "World owners and editors can update world_categories"
+on "public"."world_categories"
+as permissive
+for update
+to authenticated
+using (
+    public.world_role(world_categories.world_id, ( select auth.uid() )) in ('owner', 'editor')
+)
+with check (
+    public.world_role(world_categories.world_id, ( select auth.uid() )) in ('owner', 'editor')
+);
+
+create policy "World owners and editors can delete world_categories"
+on "public"."world_categories"
+as permissive
+for delete
+to authenticated
+using (
+    public.world_role(world_categories.world_id, ( select auth.uid() )) in ('owner', 'editor')
+);
+
+
+-- ---- world_entries --------------------------------------------------------
+-- Read policy mirrors the notes read_permissions model:
+--   only_author   -> only the entry's author
+--   only_guides   -> owner / editor / guide
+--   guides_and_author -> owner / editor / guide OR author
+--   all_players   -> any world member or linked game player
+--   public        -> any authenticated user
+
+create policy "World entries are readable per read_permissions"
+on "public"."world_entries"
+as permissive
+for select
+to authenticated
+using (
+    case world_entries.read_permissions
+        when 'public' then true
+        when 'all_players' then (
+            exists (
+                select 1 from public.world_players wp
+                where wp.world_id = world_entries.world_id
+                  and wp.user_id  = ( select auth.uid() )
+            )
+            or exists (
+                select 1 from public.game_players gp
+                join public.games g on g.id = gp.game_id
+                where g.world_id  = world_entries.world_id
+                  and gp.user_id  = ( select auth.uid() )
+            )
+        )
+        when 'guides_and_author' then (
+            world_entries.author_id = ( select auth.uid() )
+            or public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_guides' then (
+            public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_author' then (
+            world_entries.author_id = ( select auth.uid() )
+        )
+        else false
+    end
+);
+
+-- Insert: any world member or linked game player can create entries
+create policy "World members can insert world_entries"
+on "public"."world_entries"
+as permissive
+for insert
+to authenticated
+with check (
+    world_entries.author_id = ( select auth.uid() )
+    and (
+        exists (
+            select 1 from public.world_players wp
+            where wp.world_id = world_entries.world_id
+              and wp.user_id  = ( select auth.uid() )
+        )
+        or exists (
+            select 1 from public.game_players gp
+            join public.games g on g.id = gp.game_id
+            where g.world_id  = world_entries.world_id
+              and gp.user_id  = ( select auth.uid() )
+        )
+    )
+);
+
+-- Update: mirrors edit_permissions (only_author, only_guides, guides_and_author, all_players)
+create policy "World entries are writable per edit_permissions"
+on "public"."world_entries"
+as permissive
+for update
+to authenticated
+using (
+    case world_entries.edit_permissions
+        when 'all_players' then (
+            exists (
+                select 1 from public.world_players wp
+                where wp.world_id = world_entries.world_id
+                  and wp.user_id  = ( select auth.uid() )
+            )
+            or exists (
+                select 1 from public.game_players gp
+                join public.games g on g.id = gp.game_id
+                where g.world_id  = world_entries.world_id
+                  and gp.user_id  = ( select auth.uid() )
+            )
+        )
+        when 'guides_and_author' then (
+            world_entries.author_id = ( select auth.uid() )
+            or public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_guides' then (
+            public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_author' then (
+            world_entries.author_id = ( select auth.uid() )
+        )
+        else false
+    end
+)
+with check (
+    case world_entries.edit_permissions
+        when 'all_players' then (
+            exists (
+                select 1 from public.world_players wp
+                where wp.world_id = world_entries.world_id
+                  and wp.user_id  = ( select auth.uid() )
+            )
+            or exists (
+                select 1 from public.game_players gp
+                join public.games g on g.id = gp.game_id
+                where g.world_id  = world_entries.world_id
+                  and gp.user_id  = ( select auth.uid() )
+            )
+        )
+        when 'guides_and_author' then (
+            world_entries.author_id = ( select auth.uid() )
+            or public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_guides' then (
+            public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_author' then (
+            world_entries.author_id = ( select auth.uid() )
+        )
+        else false
+    end
+);
+
+-- Delete: author, owner, or editor (guides can clean up too)
+create policy "World entry authors and editors can delete world_entries"
+on "public"."world_entries"
+as permissive
+for delete
+to authenticated
+using (
+    world_entries.author_id = ( select auth.uid() )
+    or public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+);
+
+
+-- ---- world_entry_gm_data --------------------------------------------------
+-- Readable/writable only when world_role is owner, editor, or guide
+
+create policy "GMs can read world_entry_gm_data"
+on "public"."world_entry_gm_data"
+as permissive
+for select
+to authenticated
+using (
+    public.world_role(world_entry_gm_data.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+);
+
+create policy "GMs can insert world_entry_gm_data"
+on "public"."world_entry_gm_data"
+as permissive
+for insert
+to authenticated
+with check (
+    public.world_role(world_entry_gm_data.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+);
+
+create policy "GMs can update world_entry_gm_data"
+on "public"."world_entry_gm_data"
+as permissive
+for update
+to authenticated
+using (
+    public.world_role(world_entry_gm_data.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+)
+with check (
+    public.world_role(world_entry_gm_data.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+);
+
+create policy "GMs can delete world_entry_gm_data"
+on "public"."world_entry_gm_data"
+as permissive
+for delete
+to authenticated
+using (
+    public.world_role(world_entry_gm_data.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+);
+
+
+-- ---- world_entry_bonds ----------------------------------------------------
+-- Readable by any world/game member who can read the entry; writable by
+-- the character's owner (bond is on the character side).
+
+create policy "World members can read world_entry_bonds"
+on "public"."world_entry_bonds"
+as permissive
+for select
+to authenticated
+using (
+    exists (
+        select 1 from public.world_entries we
+        where we.id = world_entry_bonds.entry_id
+          and (
+            exists (
+                select 1 from public.world_players wp
+                where wp.world_id = we.world_id
+                  and wp.user_id  = ( select auth.uid() )
+            )
+            or exists (
+                select 1 from public.game_players gp
+                join public.games g on g.id = gp.game_id
+                where g.world_id  = we.world_id
+                  and gp.user_id  = ( select auth.uid() )
+            )
+          )
+    )
+);
+
+-- Characters manage their own bonds
+create policy "Character owners can insert world_entry_bonds"
+on "public"."world_entry_bonds"
+as permissive
+for insert
+to authenticated
+with check (
+    exists (
+        select 1 from public.characters c
+        where c.id  = world_entry_bonds.character_id
+          and c.uid = ( select auth.uid() )
+    )
+);
+
+create policy "Character owners can delete world_entry_bonds"
+on "public"."world_entry_bonds"
+as permissive
+for delete
+to authenticated
+using (
+    exists (
+        select 1 from public.characters c
+        where c.id  = world_entry_bonds.character_id
+          and c.uid = ( select auth.uid() )
+    )
+);
+
+
+-- ---------------------------------------------------------------------------
+-- 13. Replica identity (realtime subscriptions)
+-- ---------------------------------------------------------------------------
+
+alter table worlds             replica identity full;
+alter table world_players      replica identity full;
+alter table world_categories   replica identity full;
+alter table world_entries      replica identity full;
+alter table world_entry_gm_data replica identity full;
+alter table world_entry_bonds  replica identity full;
+
+
+-- ---------------------------------------------------------------------------
+-- 14. Realtime publication
+-- ---------------------------------------------------------------------------
+
+alter publication supabase_realtime add table worlds;
+alter publication supabase_realtime add table world_players;
+alter publication supabase_realtime add table world_categories;
+alter publication supabase_realtime add table world_entries;
+alter publication supabase_realtime add table world_entry_gm_data;
+alter publication supabase_realtime add table world_entry_bonds;
+
+
+-- ---------------------------------------------------------------------------
+-- 15. Storage buckets (via storage schema inserts — mirrors Supabase convention
+--     when storage.buckets aren't declared in config.toml)
+-- ---------------------------------------------------------------------------
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values
+    ('world_entry_images', 'world_entry_images', true,  52428800, array['image/png','image/jpeg','image/gif','image/webp']),
+    ('world_map_backgrounds', 'world_map_backgrounds', true, 52428800, array['image/png','image/jpeg','image/gif','image/webp'])
+on conflict (id) do nothing;
+
+-- Storage RLS: any authenticated world/game member can read (public bucket already
+-- exposes objects publicly, but explicit policies guard uploads/deletes).
+
+create policy "World members can upload entry images"
+on storage.objects
+as permissive
+for insert
+to authenticated
+with check (
+    bucket_id = 'world_entry_images'
+    and auth.uid() is not null
+);
+
+create policy "World members can upload map backgrounds"
+on storage.objects
+as permissive
+for insert
+to authenticated
+with check (
+    bucket_id = 'world_map_backgrounds'
+    and auth.uid() is not null
+);
+
+create policy "World entry images are publicly readable"
+on storage.objects
+as permissive
+for select
+to public
+using ( bucket_id = 'world_entry_images' );
+
+create policy "World map backgrounds are publicly readable"
+on storage.objects
+as permissive
+for select
+to public
+using ( bucket_id = 'world_map_backgrounds' );
+
+create policy "Authenticated users can delete world entry images"
+on storage.objects
+as permissive
+for delete
+to authenticated
+using (
+    bucket_id = 'world_entry_images'
+    and owner = ( select auth.uid() )
+);
+
+create policy "Authenticated users can delete world map backgrounds"
+on storage.objects
+as permissive
+for delete
+to authenticated
+using (
+    bucket_id = 'world_map_backgrounds'
+    and owner = ( select auth.uid() )
+);


### PR DESCRIPTION
## Summary

First implementation slice of the worlds feature (task W1 in the `iron-link-parity` planning docs): the full Supabase schema, RLS, and storage layer that the worlds data layer (W2+) will build on. No app code besides regenerated types.

### Tables

- `worlds` — name/description/`setting_key` only. **No playset columns by design**: the world's effective playset is derived at read time as the union of linked games' playsets (see `iron-link-parity/01-worlds.md`).
- `world_players` — explicit membership (`owner`/`editor`/`viewer`); governance lives here, content access is mostly derived from game roles.
- `games.world_id` — nullable FK; one world per game, many games per world.
- `world_categories` — generic category system (capability flags + `field_definitions` JSONB, including pinned oracle bindings).
- `world_entries` — denormalized `world_id`, self-referencing hierarchy, notes-style per-entry read/edit permissions (reuses the existing `note_read_permissions`/`note_edit_permissions` enums), Yjs `notes_content`, map JSONB.
- `world_entry_gm_data` — GM-only values as separate rows (Postgres RLS is row-level).
- `world_entry_bonds` — entry × character join.

### Access model

- `world_role(world_id, uid)` helper: best of explicit `world_players` role and roles derived from linked games (`guide` → GM-equivalent). `owner`/`editor` can only come from explicit membership, so game guides get **content** authority but cannot rename/delete the world or manage members. Members can always remove their own membership row.
- World read = explicit member OR player in any linked game — expressed directly in policy; no permission syncing.
- Realtime: replica identity FULL + `supabase_realtime` publication on all six tables, matching the existing subscribed tables.

### Storage

Two public-read buckets, `world_entry_images` and `world_map_backgrounds`, path convention `<worldId>/<entryId>/<filename>`. Writes require `world_role` on the path's world id (players may upload entry images; map backgrounds need guide/editor/owner). The uuid path guard uses `CASE WHEN` since Postgres doesn't guarantee short-circuit `AND` evaluation. Public-read is a deliberate trade-off consistent with the existing `characters`/`note_images` buckets.

## Test plan

- [x] `supabase db reset` applies the full 23-migration chain cleanly
- [x] Schema checks: `world_role()` present, RLS enabled on all six tables, `games.world_id` exists
- [x] 13 policy behavior tests via psql with simulated JWT claims: owner allowed / outsider denied / malformed storage path returns false without error / player allowed on entry images, denied on map backgrounds / self-removal allowed / non-owner cannot manage other members
- [x] `npm run supabase:gen-types` regenerated; `npm run tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)