### PR TITLE
fix: correct confirm() callers for material-ui-confirm v4

### DIFF
--- a/src/pages/games/characterSheet/components/AssetsSection/AssetsSectionCard.tsx
+++ b/src/pages/games/characterSheet/components/AssetsSection/AssetsSectionCard.tsx
@@ -68,7 +68,8 @@ function AssetsSectionCardUnMemoized(props: AssetsSectionCardProps) {
       ),
       confirmationText: t("common.delete", "Delete"),
     })
-      .then(() => {
+      .then(({ confirmed }) => {
+        if (!confirmed) return;
         deleteAsset(assetId).catch(() => {});
       })
       .catch(() => {});

--- a/src/pages/games/characterSheet/components/CharacterSettingsMenu/DeleteCharacterButton.tsx
+++ b/src/pages/games/characterSheet/components/CharacterSettingsMenu/DeleteCharacterButton.tsx
@@ -48,8 +48,9 @@ export function DeleteCharacterButton(props: DeleteCharacterButtonProps) {
         ),
         confirmationText: t("common.delete", "Delete"),
       })
-        .then(() => {
+        .then(({ confirmed }) => {
           closeMenu();
+          if (!confirmed) return;
           navigate(
             hasMoreThanOneCharacter
               ? pathConfig.game(gameId)

--- a/src/pages/games/characterSheet/components/NotesSection/FolderView/useDeleteFolder.ts
+++ b/src/pages/games/characterSheet/components/NotesSection/FolderView/useDeleteFolder.ts
@@ -42,7 +42,8 @@ export function useDeleteFolder() {
           ),
           confirmationText: t("common.delete", "Delete"),
         })
-          .then(() => {
+          .then(({ confirmed }) => {
+            if (!confirmed) return;
             if (
               currentItem?.type === "folder" &&
               currentItem.itemId === folderId

--- a/src/pages/games/characterSheet/components/NotesSection/NoteView/NoteToolbarActionsMenu.tsx
+++ b/src/pages/games/characterSheet/components/NotesSection/NoteView/NoteToolbarActionsMenu.tsx
@@ -53,7 +53,8 @@ export function NoteToolbarActionsMenu(props: NoteToolbarActionsMenuProps) {
       ),
       confirmationText: t("common.delete", "Delete"),
     })
-      .then(() => {
+      .then(({ confirmed }) => {
+        if (!confirmed) return;
         setOpenNote({ type: "folder", id: parentFolderId });
         deleteNote(openNoteId).catch(() => {});
       })

--- a/src/pages/games/characterSheet/components/NotesSection/NoteView/useDeleteNote.ts
+++ b/src/pages/games/characterSheet/components/NotesSection/NoteView/useDeleteNote.ts
@@ -32,7 +32,8 @@ export function useDeleteNote() {
           ),
           confirmationText: t("common.delete", "Delete"),
         })
-          .then(() => {
+          .then(({ confirmed }) => {
+            if (!confirmed) return;
             if (currentItem?.type === "note" && currentItem.itemId === noteId) {
               openTab({ type: "folder", id: parentFolderId });
             }

--- a/src/pages/games/characterSheet/components/TracksSection/TrackClock.tsx
+++ b/src/pages/games/characterSheet/components/TracksSection/TrackClock.tsx
@@ -116,7 +116,8 @@ export function TrackClock(props: TrackClockProps) {
       ),
       confirmationText: t("common.delete", "Delete"),
     })
-      .then(() => {
+      .then(({ confirmed }) => {
+        if (!confirmed) return;
         deleteTrack(clockId).catch(() => {});
       })
       .catch(() => {});

--- a/src/pages/games/characterSheet/components/TracksSection/TrackProgressTrack.tsx
+++ b/src/pages/games/characterSheet/components/TracksSection/TrackProgressTrack.tsx
@@ -84,7 +84,8 @@ export function TrackProgressTrack(props: TrackProgressTrackProps) {
       ),
       confirmationText: t("common.delete", "Delete"),
     })
-      .then(() => {
+      .then(({ confirmed }) => {
+        if (!confirmed) return;
         deleteTrack(trackId)
           .then(() => {
             announce(

--- a/src/pages/games/overviewSheet/UserCard.tsx
+++ b/src/pages/games/overviewSheet/UserCard.tsx
@@ -91,7 +91,8 @@ export function UserCard(props: UserCardProps) {
           "Remove User",
         ),
       })
-        .then(() => {
+        .then(({ confirmed }) => {
+          if (!confirmed) return;
           removePlayerFromGame(gameId, uid, charactersByUser[uid] ?? []).catch(
             () => {},
           );

--- a/src/pages/games/overviewSheet/gameSettings/GameSettingsMenuItems.tsx
+++ b/src/pages/games/overviewSheet/gameSettings/GameSettingsMenuItems.tsx
@@ -64,7 +64,11 @@ export function GameSettingsMenuItems(props: GameSettingsMenuItemsProps) {
         confirmationText: t("common.delete", "Delete"),
         confirmationButtonProps: { color: "error" },
       })
-        .then(() => {
+        .then(({ confirmed }) => {
+          if (!confirmed) {
+            closeMenu();
+            return;
+          }
           deleteGame(gameId)
             .then(() => {
               navigate(pathConfig.gameSelect);

--- a/src/pages/games/selectPage/GameCharacterPortraits.tsx
+++ b/src/pages/games/selectPage/GameCharacterPortraits.tsx
@@ -45,6 +45,7 @@ export function GameCharacterPortraits(props: GameCharacterPortraitsProps) {
         name={sortedCampaignCharacters[0][1].name}
         size={"large"}
         borderWidth={1}
+        sx={{ flexShrink: 0 }}
       />
     );
   }
@@ -52,6 +53,7 @@ export function GameCharacterPortraits(props: GameCharacterPortraitsProps) {
     return (
       <Box
         position={"relative"}
+        flexShrink={0}
         width={AVATAR_SIZES.large}
         height={AVATAR_SIZES.large}
       >
@@ -80,6 +82,7 @@ export function GameCharacterPortraits(props: GameCharacterPortraitsProps) {
     <Box
       display="flex"
       gap={-1}
+      flexShrink={0}
       flexWrap="wrap"
       width={AVATAR_SIZES.large}
       height={AVATAR_SIZES.large}


### PR DESCRIPTION
## Summary

- `material-ui-confirm` v4 changed `confirm()` to always resolve (returning `{ confirmed, reason }`) instead of rejecting on cancel. Every existing caller used the v3 pattern `.then(() => doAction()).catch(() => {})`, which meant **cancelling a confirm dialog still performed the destructive action**.
- Fixed all 9 callers by destructuring `{ confirmed }` and returning early when `false`.
- Affected flows: delete note, delete folder, delete asset, delete character, delete clock, delete progress track, kick player from game, delete game.

## Test plan

- [ ] Cancel a delete-note dialog → note is not deleted
- [ ] Cancel a delete-folder dialog → folder is not deleted
- [ ] Cancel a delete-asset dialog → asset is not deleted
- [ ] Cancel a delete-character dialog → character is not deleted
- [ ] Cancel a delete clock / progress track dialog → track is not deleted
- [ ] Cancel a kick-player dialog → player is not removed
- [ ] Cancel a delete-game dialog → game is not deleted
- [ ] Confirm each of the above → action still executes correctly

Verified locally: cancel no longer deletes; confirm still deletes (DB row count confirmed via local Supabase). `tsc -b` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)