### PR TITLE
feat(worlds): add worlds data layer (W2)

### DIFF
--- a/src/providers/SnackbarProvider/useSnackbar.tsx
+++ b/src/providers/SnackbarProvider/useSnackbar.tsx
@@ -152,6 +152,22 @@ function getTranslatedNoun(noun: ErrorNoun, plural: boolean): string {
       return plural
         ? i18n.t("errors.gameInviteKeys", "game invite keys")
         : i18n.t("errors.gameInviteKey", "game invite key");
+    case ErrorNoun.World:
+      return plural
+        ? i18n.t("errors.worlds", "worlds")
+        : i18n.t("errors.world", "world");
+    case ErrorNoun.WorldPlayer:
+      return plural
+        ? i18n.t("errors.worldPlayers", "players")
+        : i18n.t("errors.worldPlayer", "player");
+    case ErrorNoun.WorldCategory:
+      return plural
+        ? i18n.t("errors.worldCategories", "categories")
+        : i18n.t("errors.worldCategory", "category");
+    case ErrorNoun.WorldEntry:
+      return plural
+        ? i18n.t("errors.worldEntries", "entries")
+        : i18n.t("errors.worldEntry", "entry");
     default:
       return "";
   }

--- a/src/repositories/errors/RepositoryErrors.ts
+++ b/src/repositories/errors/RepositoryErrors.ts
@@ -16,6 +16,10 @@ export enum ErrorNoun {
   Tracks = "tracks",
   User = "user",
   Image = "image",
+  World = "world",
+  WorldPlayers = "world players",
+  WorldCategories = "world categories",
+  WorldEntries = "world entries",
 }
 
 export enum ErrorVerb {

--- a/src/repositories/errors/RepositoryErrors.ts
+++ b/src/repositories/errors/RepositoryErrors.ts
@@ -17,9 +17,9 @@ export enum ErrorNoun {
   User = "user",
   Image = "image",
   World = "world",
-  WorldPlayers = "world players",
-  WorldCategories = "world categories",
-  WorldEntries = "world entries",
+  WorldPlayer = "world player",
+  WorldCategory = "world category",
+  WorldEntry = "world entry",
 }
 
 export enum ErrorVerb {

--- a/src/repositories/shared.types.ts
+++ b/src/repositories/shared.types.ts
@@ -37,3 +37,14 @@ export enum EditPermissions {
   GuidesAndAuthor = "guides_and_author",
   AllPlayers = "all_players",
 }
+// Mirrors the values returned by the world_role() database function:
+// owner/editor/viewer come from explicit world_players rows, guide/player
+// are derived live from game_players rows on linked games.
+export enum WorldPermission {
+  Owner = "owner",
+  Editor = "editor",
+  Guide = "guide",
+  Player = "player",
+  Viewer = "viewer",
+  None = "none",
+}

--- a/src/repositories/storage.repository.ts
+++ b/src/repositories/storage.repository.ts
@@ -6,7 +6,11 @@ import {
   getRepositoryError,
 } from "./errors/RepositoryErrors";
 
-type BucketNames = "characters" | "note_images";
+type BucketNames =
+  | "characters"
+  | "note_images"
+  | "world_entry_images"
+  | "world_map_backgrounds";
 
 export class StorageRepository {
   public static async storeImage(

--- a/src/repositories/worldCategories.repository.ts
+++ b/src/repositories/worldCategories.repository.ts
@@ -1,0 +1,204 @@
+import { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+
+import {
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from "types/supabase-generated.type";
+
+import { supabase } from "lib/supabase.lib";
+
+import { createSubscription } from "./_subscriptionManager";
+import {
+  ErrorNoun,
+  ErrorVerb,
+  RepositoryError,
+  getRepositoryError,
+} from "./errors/RepositoryErrors";
+
+// JSON shape stored in world_categories.field_definitions.
+// Bindings are pinned and concrete: the picker browses the world's effective
+// playset with `replaces` applied, so what the user picked is what is stored.
+export interface OracleBindingDTO {
+  packageId: string;
+  oracleId: string;
+  // What the binding actually resolved to last time; a difference against a
+  // fresh resolution is a divergence and must be surfaced, never silent.
+  resolvedOracleId: string;
+  // Escape hatch: ignore replacements, always roll exactly oracleId.
+  exact?: boolean;
+}
+
+export type FieldDefinitionType =
+  | "text"
+  | "richText"
+  | "oracleText"
+  | "image"
+  | "tags";
+
+export interface FieldDefinitionDTO {
+  key: string;
+  label: string;
+  type: FieldDefinitionType;
+  binding?: OracleBindingDTO;
+  // Value lives in world_entry_gm_data, RLS-protected.
+  gmOnly?: boolean;
+}
+
+export type WorldCategoryDTO = Tables<"world_categories">;
+export type WorldCategoryInsertDTO = TablesInsert<"world_categories">;
+export type WorldCategoryUpdateDTO = TablesUpdate<"world_categories">;
+
+export class WorldCategoriesRepository {
+  private static worldCategories = () => supabase.from("world_categories");
+
+  public static listenToWorldCategories(
+    worldId: string,
+    onWorldCategoryChanges: (
+      changedCategories: Record<string, WorldCategoryDTO>,
+      removedCategoryIds: string[],
+      replaceState: boolean,
+    ) => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    const startInitialLoad = () => {
+      this.worldCategories()
+        .select("*")
+        .eq("world_id", worldId)
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            onError(
+              getRepositoryError(
+                error,
+                ErrorVerb.Read,
+                ErrorNoun.WorldCategories,
+                true,
+                status,
+              ),
+            );
+          } else {
+            onWorldCategoryChanges(
+              Object.fromEntries(
+                data.map((category) => [category.id, category]),
+              ),
+              [],
+              true,
+            );
+          }
+        });
+    };
+
+    const handlePayload = (
+      payload: RealtimePostgresChangesPayload<WorldCategoryDTO>,
+    ) => {
+      if (payload.errors) {
+        onError(
+          getRepositoryError(
+            payload.errors,
+            ErrorVerb.Read,
+            ErrorNoun.WorldCategories,
+            true,
+          ),
+        );
+      } else if (
+        payload.eventType === "INSERT" ||
+        payload.eventType === "UPDATE"
+      ) {
+        onWorldCategoryChanges({ [payload.new.id]: payload.new }, [], false);
+      } else if (payload.eventType === "DELETE" && payload.old.id) {
+        onWorldCategoryChanges({}, [payload.old.id], false);
+      }
+    };
+
+    const unsubscribe = createSubscription(
+      `world_categories:world_id=eq.${worldId}`,
+      "world_categories",
+      `world_id=eq.${worldId}`,
+      startInitialLoad,
+      handlePayload,
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }
+
+  public static addWorldCategory(
+    category: WorldCategoryInsertDTO,
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.worldCategories()
+        .insert(category)
+        .select()
+        .single()
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Create,
+                ErrorNoun.WorldCategories,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve(data.id);
+          }
+        });
+    });
+  }
+
+  public static updateWorldCategory(
+    categoryId: string,
+    category: WorldCategoryUpdateDTO,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worldCategories()
+        .update(category)
+        .eq("id", categoryId)
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Update,
+                ErrorNoun.WorldCategories,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+
+  public static deleteWorldCategory(categoryId: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worldCategories()
+        .delete()
+        .eq("id", categoryId)
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Delete,
+                ErrorNoun.WorldCategories,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+}

--- a/src/repositories/worldCategories.repository.ts
+++ b/src/repositories/worldCategories.repository.ts
@@ -72,7 +72,7 @@ export class WorldCategoriesRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Read,
-                ErrorNoun.WorldCategories,
+                ErrorNoun.WorldCategory,
                 true,
                 status,
               ),
@@ -97,7 +97,7 @@ export class WorldCategoriesRepository {
           getRepositoryError(
             payload.errors,
             ErrorVerb.Read,
-            ErrorNoun.WorldCategories,
+            ErrorNoun.WorldCategory,
             true,
           ),
         );
@@ -139,7 +139,7 @@ export class WorldCategoriesRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Create,
-                ErrorNoun.WorldCategories,
+                ErrorNoun.WorldCategory,
                 false,
                 status,
               ),
@@ -166,7 +166,7 @@ export class WorldCategoriesRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Update,
-                ErrorNoun.WorldCategories,
+                ErrorNoun.WorldCategory,
                 false,
                 status,
               ),
@@ -190,7 +190,7 @@ export class WorldCategoriesRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Delete,
-                ErrorNoun.WorldCategories,
+                ErrorNoun.WorldCategory,
                 false,
                 status,
               ),

--- a/src/repositories/worldEntries.repository.ts
+++ b/src/repositories/worldEntries.repository.ts
@@ -111,7 +111,7 @@ export class WorldEntriesRepository {
             getRepositoryError(
               error,
               ErrorVerb.Read,
-              ErrorNoun.WorldEntries,
+              ErrorNoun.WorldEntry,
               true,
               status,
             ),
@@ -139,7 +139,7 @@ export class WorldEntriesRepository {
           getRepositoryError(
             payload.errors,
             ErrorVerb.Read,
-            ErrorNoun.WorldEntries,
+            ErrorNoun.WorldEntry,
             true,
           ),
         );
@@ -184,7 +184,7 @@ export class WorldEntriesRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Create,
-                ErrorNoun.WorldEntries,
+                ErrorNoun.WorldEntry,
                 false,
                 status,
               ),
@@ -211,7 +211,7 @@ export class WorldEntriesRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Update,
-                ErrorNoun.WorldEntries,
+                ErrorNoun.WorldEntry,
                 false,
                 status,
               ),
@@ -247,7 +247,7 @@ export class WorldEntriesRepository {
             getRepositoryError(
               res,
               ErrorVerb.Update,
-              ErrorNoun.WorldEntries,
+              ErrorNoun.WorldEntry,
               false,
               res.status,
             ),
@@ -273,7 +273,7 @@ export class WorldEntriesRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Read,
-                ErrorNoun.WorldEntries,
+                ErrorNoun.WorldEntry,
                 false,
                 status,
               ),
@@ -297,7 +297,7 @@ export class WorldEntriesRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Delete,
-                ErrorNoun.WorldEntries,
+                ErrorNoun.WorldEntry,
                 false,
                 status,
               ),

--- a/src/repositories/worldEntries.repository.ts
+++ b/src/repositories/worldEntries.repository.ts
@@ -1,0 +1,311 @@
+import { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+
+import {
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from "types/supabase-generated.type";
+
+import { SUPABASE_ANON_KEY, SUPABASE_URL, supabase } from "lib/supabase.lib";
+
+import { createSubscription } from "./_subscriptionManager";
+import {
+  ErrorNoun,
+  ErrorVerb,
+  RepositoryError,
+  getRepositoryError,
+} from "./errors/RepositoryErrors";
+import { WorldPermission } from "./shared.types";
+
+export type WorldEntryDTO = Tables<"world_entries">;
+export type WorldEntryInsertDTO = TablesInsert<"world_entries">;
+export type WorldEntryUpdateDTO = TablesUpdate<"world_entries">;
+
+// Everything except notes_content, which is a large Yjs byte column fetched
+// on demand (mirrors how notes exclude note_content_bytes from list queries).
+const ENTRY_LIST_COLUMNS = `
+  id,
+  world_id,
+  category_id,
+  parent_entry_id,
+  name,
+  icon,
+  image_filenames,
+  fields,
+  map,
+  map_background_filename,
+  map_settings,
+  read_permissions,
+  edit_permissions,
+  author_id,
+  created_at,
+  updated_at
+`;
+
+function isGuideEquivalent(permission: WorldPermission): boolean {
+  return (
+    permission === WorldPermission.Owner ||
+    permission === WorldPermission.Editor ||
+    permission === WorldPermission.Guide
+  );
+}
+
+// Mirrors the world_entries select policy so realtime payloads are filtered
+// the same way RLS filters the initial load.
+function canReadEntry(
+  entry: Pick<WorldEntryDTO, "read_permissions" | "author_id">,
+  uid: string | undefined,
+  permission: WorldPermission,
+): boolean {
+  switch (entry.read_permissions) {
+    case "public":
+      return true;
+    case "all_players":
+      return permission !== WorldPermission.None;
+    case "guides_and_author":
+      return entry.author_id === uid || isGuideEquivalent(permission);
+    case "only_guides":
+      return isGuideEquivalent(permission);
+    case "only_author":
+      return entry.author_id === uid;
+    default:
+      return false;
+  }
+}
+
+export class WorldEntriesRepository {
+  private static worldEntries = () => supabase.from("world_entries");
+
+  public static listenToWorldEntries(
+    uid: string | undefined,
+    worldId: string,
+    permission: WorldPermission,
+    onWorldEntryChanges: (
+      changedEntries: Record<string, WorldEntryDTO>,
+      removedEntryIds: string[],
+      replaceState: boolean,
+    ) => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    const startInitialLoad = () => {
+      const query = this.worldEntries()
+        .select(ENTRY_LIST_COLUMNS)
+        .eq("world_id", worldId);
+
+      if (permission === WorldPermission.None) {
+        query.eq("read_permissions", "public");
+      } else if (!isGuideEquivalent(permission)) {
+        query.or(
+          `read_permissions.eq."public",read_permissions.eq."all_players",and(read_permissions.eq."only_author",author_id.eq."${uid}"),and(read_permissions.eq."guides_and_author",author_id.eq."${uid}")`,
+        );
+      } else {
+        query.or(
+          `read_permissions.eq."public",read_permissions.eq."all_players",read_permissions.eq."only_guides",read_permissions.eq."guides_and_author",and(read_permissions.eq."only_author",author_id.eq."${uid}")`,
+        );
+      }
+
+      query.then(({ data, error, status }) => {
+        if (error) {
+          console.error(error);
+          onError(
+            getRepositoryError(
+              error,
+              ErrorVerb.Read,
+              ErrorNoun.WorldEntries,
+              true,
+              status,
+            ),
+          );
+        } else {
+          onWorldEntryChanges(
+            Object.fromEntries(
+              data.map((entry) => [
+                entry.id,
+                entry as unknown as WorldEntryDTO,
+              ]),
+            ),
+            [],
+            true,
+          );
+        }
+      });
+    };
+
+    const handlePayload = (
+      payload: RealtimePostgresChangesPayload<WorldEntryDTO>,
+    ) => {
+      if (payload.errors) {
+        onError(
+          getRepositoryError(
+            payload.errors,
+            ErrorVerb.Read,
+            ErrorNoun.WorldEntries,
+            true,
+          ),
+        );
+      } else if (
+        payload.eventType === "INSERT" ||
+        payload.eventType === "UPDATE"
+      ) {
+        if (canReadEntry(payload.new, uid, permission)) {
+          onWorldEntryChanges({ [payload.new.id]: payload.new }, [], false);
+        } else {
+          // A permission change can revoke access to an entry we already hold
+          onWorldEntryChanges({}, [payload.new.id], false);
+        }
+      } else if (payload.eventType === "DELETE" && payload.old.id) {
+        onWorldEntryChanges({}, [payload.old.id], false);
+      }
+    };
+
+    const unsubscribe = createSubscription(
+      `world_entries:world_id=eq.${worldId}`,
+      "world_entries",
+      `world_id=eq.${worldId}`,
+      startInitialLoad,
+      handlePayload,
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }
+
+  public static addWorldEntry(entry: WorldEntryInsertDTO): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.worldEntries()
+        .insert(entry)
+        .select()
+        .single()
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Create,
+                ErrorNoun.WorldEntries,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve(data.id);
+          }
+        });
+    });
+  }
+
+  public static updateWorldEntry(
+    entryId: string,
+    entry: WorldEntryUpdateDTO,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worldEntries()
+        .update(entry)
+        .eq("id", entryId)
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Update,
+                ErrorNoun.WorldEntries,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+
+  public static updateWorldEntryBeaconRequest(
+    token: string,
+    entryId: string,
+    entry: WorldEntryUpdateDTO,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const endpoint = `${SUPABASE_URL}/rest/v1/world_entries?id=eq.${entryId}`;
+      fetch(endpoint, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+          Prefer: "return=minimal",
+          Apikey: SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify(entry),
+        keepalive: true,
+      }).then((res) => {
+        if (!res.ok) {
+          console.error(res);
+          reject(
+            getRepositoryError(
+              res,
+              ErrorVerb.Update,
+              ErrorNoun.WorldEntries,
+              false,
+              res.status,
+            ),
+          );
+        }
+        resolve();
+      });
+    });
+  }
+
+  public static getWorldEntryNotesContent(
+    entryId: string,
+  ): Promise<WorldEntryDTO> {
+    return new Promise((resolve, reject) => {
+      this.worldEntries()
+        .select("notes_content")
+        .eq("id", entryId)
+        .single()
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Read,
+                ErrorNoun.WorldEntries,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve(data as WorldEntryDTO);
+          }
+        });
+    });
+  }
+
+  public static deleteWorldEntry(entryId: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worldEntries()
+        .delete()
+        .eq("id", entryId)
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Delete,
+                ErrorNoun.WorldEntries,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+}

--- a/src/repositories/worldEntryGmData.repository.ts
+++ b/src/repositories/worldEntryGmData.repository.ts
@@ -1,0 +1,151 @@
+import { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+
+import { Tables, TablesInsert } from "types/supabase-generated.type";
+
+import { supabase } from "lib/supabase.lib";
+
+import { createSubscription } from "./_subscriptionManager";
+import {
+  ErrorNoun,
+  ErrorVerb,
+  RepositoryError,
+  getRepositoryError,
+} from "./errors/RepositoryErrors";
+
+export type WorldEntryGmDataDTO = Tables<"world_entry_gm_data">;
+export type WorldEntryGmDataInsertDTO = TablesInsert<"world_entry_gm_data">;
+
+// RLS restricts every operation on this table to owner/editor/guide roles;
+// callers should only listen when the user has GM-equivalent access.
+export class WorldEntryGmDataRepository {
+  private static worldEntryGmData = () => supabase.from("world_entry_gm_data");
+
+  public static listenToWorldEntryGmData(
+    worldId: string,
+    onGmDataChanges: (
+      changedGmData: Record<string, WorldEntryGmDataDTO>,
+      removedEntryIds: string[],
+      replaceState: boolean,
+    ) => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    const startInitialLoad = () => {
+      // gm_notes_content is a large Yjs byte column fetched on demand
+      this.worldEntryGmData()
+        .select("entry_id, world_id, fields, created_at, updated_at")
+        .eq("world_id", worldId)
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            onError(
+              getRepositoryError(
+                error,
+                ErrorVerb.Read,
+                ErrorNoun.WorldEntries,
+                true,
+                status,
+              ),
+            );
+          } else {
+            onGmDataChanges(
+              Object.fromEntries(
+                data.map((row) => [
+                  row.entry_id,
+                  row as unknown as WorldEntryGmDataDTO,
+                ]),
+              ),
+              [],
+              true,
+            );
+          }
+        });
+    };
+
+    const handlePayload = (
+      payload: RealtimePostgresChangesPayload<WorldEntryGmDataDTO>,
+    ) => {
+      if (payload.errors) {
+        onError(
+          getRepositoryError(
+            payload.errors,
+            ErrorVerb.Read,
+            ErrorNoun.WorldEntries,
+            true,
+          ),
+        );
+      } else if (
+        payload.eventType === "INSERT" ||
+        payload.eventType === "UPDATE"
+      ) {
+        onGmDataChanges({ [payload.new.entry_id]: payload.new }, [], false);
+      } else if (payload.eventType === "DELETE" && payload.old.entry_id) {
+        onGmDataChanges({}, [payload.old.entry_id], false);
+      }
+    };
+
+    const unsubscribe = createSubscription(
+      `world_entry_gm_data:world_id=eq.${worldId}`,
+      "world_entry_gm_data",
+      `world_id=eq.${worldId}`,
+      startInitialLoad,
+      handlePayload,
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }
+
+  // Returns null when the entry has no GM data row yet.
+  public static getWorldEntryGmNotesContent(
+    entryId: string,
+  ): Promise<WorldEntryGmDataDTO | null> {
+    return new Promise((resolve, reject) => {
+      this.worldEntryGmData()
+        .select("gm_notes_content")
+        .eq("entry_id", entryId)
+        .maybeSingle()
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Read,
+                ErrorNoun.WorldEntries,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve(data as WorldEntryGmDataDTO | null);
+          }
+        });
+    });
+  }
+
+  public static upsertWorldEntryGmData(
+    gmData: WorldEntryGmDataInsertDTO,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worldEntryGmData()
+        .upsert(gmData, { onConflict: "entry_id" })
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Update,
+                ErrorNoun.WorldEntries,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+}

--- a/src/repositories/worldEntryGmData.repository.ts
+++ b/src/repositories/worldEntryGmData.repository.ts
@@ -41,7 +41,7 @@ export class WorldEntryGmDataRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Read,
-                ErrorNoun.WorldEntries,
+                ErrorNoun.WorldEntry,
                 true,
                 status,
               ),
@@ -69,7 +69,7 @@ export class WorldEntryGmDataRepository {
           getRepositoryError(
             payload.errors,
             ErrorVerb.Read,
-            ErrorNoun.WorldEntries,
+            ErrorNoun.WorldEntry,
             true,
           ),
         );
@@ -112,7 +112,7 @@ export class WorldEntryGmDataRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Read,
-                ErrorNoun.WorldEntries,
+                ErrorNoun.WorldEntry,
                 false,
                 status,
               ),
@@ -137,7 +137,7 @@ export class WorldEntryGmDataRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Update,
-                ErrorNoun.WorldEntries,
+                ErrorNoun.WorldEntry,
                 false,
                 status,
               ),

--- a/src/repositories/worldPlayers.repository.ts
+++ b/src/repositories/worldPlayers.repository.ts
@@ -1,0 +1,175 @@
+import { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+
+import { Tables } from "types/supabase-generated.type";
+
+import { supabase } from "lib/supabase.lib";
+
+import { createSubscription } from "./_subscriptionManager";
+import {
+  ErrorNoun,
+  ErrorVerb,
+  RepositoryError,
+  getRepositoryError,
+} from "./errors/RepositoryErrors";
+
+export type WorldPlayerDTO = Tables<"world_players">;
+
+export class WorldPlayersRepository {
+  private static worldPlayers = () => supabase.from("world_players");
+
+  public static listenToWorldPlayers(
+    worldId: string,
+    onWorldPlayerChanges: (
+      changedWorldPlayers: Record<string, WorldPlayerDTO>,
+      removedWorldPlayerIds: string[],
+      replaceState: boolean,
+    ) => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    const startInitialLoad = () => {
+      this.worldPlayers()
+        .select("*")
+        .eq("world_id", worldId)
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            onError(
+              getRepositoryError(
+                error,
+                ErrorVerb.Read,
+                ErrorNoun.WorldPlayers,
+                true,
+                status,
+              ),
+            );
+          } else {
+            onWorldPlayerChanges(
+              Object.fromEntries(
+                data.map((player) => [player.user_id, player]),
+              ),
+              [],
+              true,
+            );
+          }
+        });
+    };
+
+    const handlePayload = (
+      payload: RealtimePostgresChangesPayload<WorldPlayerDTO>,
+    ) => {
+      if (payload.errors) {
+        onError(
+          getRepositoryError(
+            payload.errors,
+            ErrorVerb.Read,
+            ErrorNoun.WorldPlayers,
+            true,
+          ),
+        );
+      } else if (
+        payload.eventType === "INSERT" ||
+        payload.eventType === "UPDATE"
+      ) {
+        onWorldPlayerChanges({ [payload.new.user_id]: payload.new }, [], false);
+      } else if (payload.eventType === "DELETE" && payload.old.user_id) {
+        onWorldPlayerChanges({}, [payload.old.user_id], false);
+      }
+    };
+
+    const unsubscribe = createSubscription(
+      `world_players:world_id=eq.${worldId}`,
+      "world_players",
+      `world_id=eq.${worldId}`,
+      startInitialLoad,
+      handlePayload,
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }
+
+  public static addWorldPlayer(
+    worldId: string,
+    userId: string,
+    role: WorldPlayerDTO["role"],
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worldPlayers()
+        .insert({ world_id: worldId, user_id: userId, role })
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Create,
+                ErrorNoun.WorldPlayers,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+
+  public static updateWorldPlayerRole(
+    worldId: string,
+    userId: string,
+    role: WorldPlayerDTO["role"],
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worldPlayers()
+        .update({ role })
+        .eq("world_id", worldId)
+        .eq("user_id", userId)
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Update,
+                ErrorNoun.WorldPlayers,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+
+  public static removeWorldPlayer(
+    worldId: string,
+    userId: string,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worldPlayers()
+        .delete()
+        .eq("world_id", worldId)
+        .eq("user_id", userId)
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Delete,
+                ErrorNoun.WorldPlayers,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+}

--- a/src/repositories/worldPlayers.repository.ts
+++ b/src/repositories/worldPlayers.repository.ts
@@ -37,7 +37,7 @@ export class WorldPlayersRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Read,
-                ErrorNoun.WorldPlayers,
+                ErrorNoun.WorldPlayer,
                 true,
                 status,
               ),
@@ -62,7 +62,7 @@ export class WorldPlayersRepository {
           getRepositoryError(
             payload.errors,
             ErrorVerb.Read,
-            ErrorNoun.WorldPlayers,
+            ErrorNoun.WorldPlayer,
             true,
           ),
         );
@@ -104,7 +104,7 @@ export class WorldPlayersRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Create,
-                ErrorNoun.WorldPlayers,
+                ErrorNoun.WorldPlayer,
                 false,
                 status,
               ),
@@ -133,7 +133,7 @@ export class WorldPlayersRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Update,
-                ErrorNoun.WorldPlayers,
+                ErrorNoun.WorldPlayer,
                 false,
                 status,
               ),
@@ -161,7 +161,7 @@ export class WorldPlayersRepository {
               getRepositoryError(
                 error,
                 ErrorVerb.Delete,
-                ErrorNoun.WorldPlayers,
+                ErrorNoun.WorldPlayer,
                 false,
                 status,
               ),

--- a/src/repositories/worlds.repository.ts
+++ b/src/repositories/worlds.repository.ts
@@ -1,0 +1,227 @@
+import { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+
+import { Tables, TablesUpdate } from "types/supabase-generated.type";
+
+import { supabase } from "lib/supabase.lib";
+
+import { createSubscription } from "./_subscriptionManager";
+import {
+  ErrorNoun,
+  ErrorVerb,
+  RepositoryError,
+  getRepositoryError,
+} from "./errors/RepositoryErrors";
+import { WorldPermission } from "./shared.types";
+
+export type WorldDTO = Tables<"worlds">;
+export type WorldUpdateDTO = TablesUpdate<"worlds">;
+
+export class WorldsRepository {
+  private static worlds = () => supabase.from("worlds");
+
+  public static async getWorld(worldId: string): Promise<WorldDTO> {
+    const { data, error, status } = await this.worlds()
+      .select("*")
+      .eq("id", worldId)
+      .single();
+
+    if (error) {
+      throw getRepositoryError(
+        error,
+        ErrorVerb.Read,
+        ErrorNoun.World,
+        false,
+        status,
+      );
+    }
+
+    return data;
+  }
+
+  public static listenToWorld(
+    worldId: string,
+    onWorld: (world: WorldDTO) => void,
+    onWorldDeleted: () => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    const getInitialState = () => {
+      this.getWorld(worldId).then(onWorld).catch(onError);
+    };
+
+    const handlePayload = (
+      payload: RealtimePostgresChangesPayload<WorldDTO>,
+    ) => {
+      if (payload.errors) {
+        console.error(payload.errors);
+        onError(
+          getRepositoryError(
+            payload.errors,
+            ErrorVerb.Read,
+            ErrorNoun.World,
+            false,
+          ),
+        );
+      } else if (
+        payload.eventType === "INSERT" ||
+        payload.eventType === "UPDATE"
+      ) {
+        onWorld(payload.new);
+      } else if (payload.eventType === "DELETE") {
+        onWorldDeleted();
+      }
+    };
+
+    const unsubscribe = createSubscription(
+      `worlds:id=eq.${worldId}`,
+      "worlds",
+      `id=eq.${worldId}`,
+      getInitialState,
+      handlePayload,
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }
+
+  // RLS already limits the result to worlds the user can read
+  // (explicit membership or membership in a linked game).
+  public static async getUsersWorlds(): Promise<WorldDTO[]> {
+    return new Promise((resolve, reject) => {
+      this.worlds()
+        .select("*")
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Read,
+                ErrorNoun.World,
+                true,
+                status,
+              ),
+            );
+          } else {
+            resolve(data);
+          }
+        });
+    });
+  }
+
+  // Inserts the world and the creator's owner membership row atomically;
+  // the world_players insert policy is owner-only, so the initial owner row
+  // can only be created through this security-definer function.
+  public static async createWorld(
+    name: string,
+    description: string | null,
+    settingKey: string | null,
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      supabase
+        .rpc("create_world", {
+          p_name: name,
+          p_description: description ?? undefined,
+          p_setting_key: settingKey ?? undefined,
+        })
+        .then(({ data, error, status }) => {
+          if (error || !data) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Create,
+                ErrorNoun.World,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve(data);
+          }
+        });
+    });
+  }
+
+  public static async updateWorld(
+    worldId: string,
+    world: WorldUpdateDTO,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worlds()
+        .update(world)
+        .eq("id", worldId)
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Update,
+                ErrorNoun.World,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+
+  public static async deleteWorld(worldId: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.worlds()
+        .delete()
+        .eq("id", worldId)
+        .then(({ error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Delete,
+                ErrorNoun.World,
+                false,
+                status,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        });
+    });
+  }
+
+  public static async getWorldPermission(
+    worldId: string,
+    userId: string,
+  ): Promise<WorldPermission> {
+    return new Promise((resolve, reject) => {
+      supabase
+        .rpc("world_role", { p_world_id: worldId, p_uid: userId })
+        .then(({ data, error, status }) => {
+          if (error) {
+            console.error(error);
+            reject(
+              getRepositoryError(
+                error,
+                ErrorVerb.Read,
+                ErrorNoun.World,
+                false,
+                status,
+              ),
+            );
+          } else {
+            const permissions = Object.values(WorldPermission) as string[];
+            resolve(
+              data && permissions.includes(data)
+                ? (data as WorldPermission)
+                : WorldPermission.None,
+            );
+          }
+        });
+    });
+  }
+}

--- a/src/services/worldCategories.service.ts
+++ b/src/services/worldCategories.service.ts
@@ -1,0 +1,122 @@
+import { IconDefinition } from "types/Icon.type";
+import { Json } from "types/supabase-generated.type";
+
+import { RepositoryError } from "repositories/errors/RepositoryErrors";
+import {
+  FieldDefinitionDTO,
+  OracleBindingDTO,
+  WorldCategoriesRepository,
+  WorldCategoryDTO,
+} from "repositories/worldCategories.repository";
+
+// The stored JSON already uses the domain shape (see the repository DTOs),
+// so the domain types are aliases rather than conversions.
+export type FieldDefinition = FieldDefinitionDTO;
+export type OracleBinding = OracleBindingDTO;
+
+export interface IWorldCategory {
+  id: string;
+  worldId: string;
+  name: string;
+  icon: IconDefinition | null;
+  sortOrder: number;
+  supportsHierarchy: boolean;
+  supportsMap: boolean;
+  supportsBonds: boolean;
+  fieldDefinitions: FieldDefinition[];
+}
+
+export class WorldCategoriesService {
+  public static listenToWorldCategories(
+    worldId: string,
+    onWorldCategoryChanges: (
+      changedCategories: Record<string, IWorldCategory>,
+      removedCategoryIds: string[],
+      replaceState: boolean,
+    ) => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    return WorldCategoriesRepository.listenToWorldCategories(
+      worldId,
+      (changedCategories, removedCategoryIds, replaceState) =>
+        onWorldCategoryChanges(
+          Object.fromEntries(
+            Object.entries(changedCategories).map(([categoryId, category]) => [
+              categoryId,
+              this.convertWorldCategoryDTOToWorldCategory(category),
+            ]),
+          ),
+          removedCategoryIds,
+          replaceState,
+        ),
+      onError,
+    );
+  }
+
+  public static addWorldCategory(
+    worldId: string,
+    category: {
+      name: string;
+      icon?: IconDefinition;
+      sortOrder: number;
+      supportsHierarchy?: boolean;
+      supportsMap?: boolean;
+      supportsBonds?: boolean;
+      fieldDefinitions?: FieldDefinition[];
+    },
+  ): Promise<string> {
+    return WorldCategoriesRepository.addWorldCategory({
+      world_id: worldId,
+      name: category.name,
+      icon: (category.icon ?? null) as unknown as Json,
+      sort_order: category.sortOrder,
+      supports_hierarchy: category.supportsHierarchy ?? false,
+      supports_map: category.supportsMap ?? false,
+      supports_bonds: category.supportsBonds ?? false,
+      field_definitions: (category.fieldDefinitions ?? []) as unknown as Json,
+    });
+  }
+
+  public static updateWorldCategory(
+    categoryId: string,
+    category: Partial<Omit<IWorldCategory, "id" | "worldId">>,
+  ): Promise<void> {
+    return WorldCategoriesRepository.updateWorldCategory(categoryId, {
+      name: category.name,
+      icon:
+        category.icon === undefined
+          ? undefined
+          : (category.icon as unknown as Json),
+      sort_order: category.sortOrder,
+      supports_hierarchy: category.supportsHierarchy,
+      supports_map: category.supportsMap,
+      supports_bonds: category.supportsBonds,
+      field_definitions:
+        category.fieldDefinitions === undefined
+          ? undefined
+          : (category.fieldDefinitions as unknown as Json),
+    });
+  }
+
+  public static deleteWorldCategory(categoryId: string): Promise<void> {
+    return WorldCategoriesRepository.deleteWorldCategory(categoryId);
+  }
+
+  private static convertWorldCategoryDTOToWorldCategory(
+    category: WorldCategoryDTO,
+  ): IWorldCategory {
+    return {
+      id: category.id,
+      worldId: category.world_id,
+      name: category.name,
+      icon: (category.icon as unknown as IconDefinition) ?? null,
+      sortOrder: category.sort_order,
+      supportsHierarchy: category.supports_hierarchy,
+      supportsMap: category.supports_map,
+      supportsBonds: category.supports_bonds,
+      fieldDefinitions: Array.isArray(category.field_definitions)
+        ? (category.field_definitions as unknown as FieldDefinition[])
+        : [],
+    };
+  }
+}

--- a/src/services/worldEntries.service.ts
+++ b/src/services/worldEntries.service.ts
@@ -1,0 +1,326 @@
+import { Buffer } from "buffer";
+
+import { IconDefinition } from "types/Icon.type";
+import {
+  LocationMap,
+  MapBackgroundImageFit,
+  MapStrokeColors,
+} from "types/Locations.type";
+import { Json } from "types/supabase-generated.type";
+
+import { RepositoryError } from "repositories/errors/RepositoryErrors";
+import {
+  EditPermissions,
+  ReadPermissions,
+  WorldPermission,
+} from "repositories/shared.types";
+import { StorageRepository } from "repositories/storage.repository";
+import {
+  WorldEntriesRepository,
+  WorldEntryDTO,
+} from "repositories/worldEntries.repository";
+
+// Values for text/richText/oracleText fields are strings; tags fields store
+// string arrays. Image fields store filenames in image_filenames instead.
+export type WorldEntryFieldValue = string | string[];
+
+export interface IWorldEntryMapSettings {
+  backgroundImageFit: MapBackgroundImageFit;
+  strokeColor: MapStrokeColors;
+  showMap: boolean;
+}
+
+export interface IWorldEntry {
+  id: string;
+  worldId: string;
+  categoryId: string;
+  parentEntryId: string | null;
+  name: string;
+  icon: IconDefinition | null;
+  imageFilenames: string[];
+  fields: Record<string, WorldEntryFieldValue>;
+  map: LocationMap | null;
+  mapBackgroundFilename: string | null;
+  mapSettings: IWorldEntryMapSettings | null;
+  readPermissions: ReadPermissions;
+  editPermissions: EditPermissions;
+  authorId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IWorldEntryNotesContent {
+  content: Uint8Array;
+}
+
+export class WorldEntriesService {
+  public static listenToWorldEntries(
+    uid: string | undefined,
+    worldId: string,
+    permission: WorldPermission,
+    onWorldEntryChanges: (
+      changedEntries: Record<string, IWorldEntry>,
+      removedEntryIds: string[],
+      replaceState: boolean,
+    ) => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    return WorldEntriesRepository.listenToWorldEntries(
+      uid,
+      worldId,
+      permission,
+      (changedEntries, removedEntryIds, replaceState) =>
+        onWorldEntryChanges(
+          Object.fromEntries(
+            Object.entries(changedEntries).map(([entryId, entry]) => [
+              entryId,
+              this.convertWorldEntryDTOToWorldEntry(entry),
+            ]),
+          ),
+          removedEntryIds,
+          replaceState,
+        ),
+      onError,
+    );
+  }
+
+  public static addWorldEntry(
+    uid: string,
+    worldId: string,
+    categoryId: string,
+    name: string,
+    readPermissions: ReadPermissions,
+    editPermissions: EditPermissions,
+    parentEntryId?: string,
+  ): Promise<string> {
+    return WorldEntriesRepository.addWorldEntry({
+      world_id: worldId,
+      category_id: categoryId,
+      parent_entry_id: parentEntryId ?? null,
+      name,
+      author_id: uid,
+      read_permissions: readPermissions,
+      edit_permissions: editPermissions,
+    });
+  }
+
+  public static updateWorldEntry(
+    entryId: string,
+    entry: Partial<
+      Omit<
+        IWorldEntry,
+        "id" | "worldId" | "authorId" | "createdAt" | "updatedAt"
+      >
+    >,
+  ): Promise<void> {
+    return WorldEntriesRepository.updateWorldEntry(entryId, {
+      category_id: entry.categoryId,
+      parent_entry_id: entry.parentEntryId,
+      name: entry.name,
+      icon:
+        entry.icon === undefined ? undefined : (entry.icon as unknown as Json),
+      image_filenames: entry.imageFilenames,
+      fields:
+        entry.fields === undefined
+          ? undefined
+          : (entry.fields as unknown as Json),
+      map: entry.map === undefined ? undefined : (entry.map as unknown as Json),
+      map_background_filename: entry.mapBackgroundFilename,
+      map_settings:
+        entry.mapSettings === undefined
+          ? undefined
+          : (entry.mapSettings as unknown as Json),
+      read_permissions: entry.readPermissions,
+      edit_permissions: entry.editPermissions,
+    });
+  }
+
+  public static updateWorldEntryNotesContent(
+    entryId: string,
+    content: Uint8Array,
+  ): Promise<void> {
+    return WorldEntriesRepository.updateWorldEntry(entryId, {
+      notes_content: this.uint8ArrayToDatabase(content),
+    });
+  }
+
+  public static updateWorldEntryNotesContentBeacon(
+    entryId: string,
+    content: Uint8Array,
+    token: string,
+  ): Promise<void> {
+    return WorldEntriesRepository.updateWorldEntryBeaconRequest(
+      token,
+      entryId,
+      {
+        notes_content: this.uint8ArrayToDatabase(content),
+      },
+    );
+  }
+
+  public static async getWorldEntryNotesContent(
+    entryId: string,
+  ): Promise<IWorldEntryNotesContent> {
+    const entry =
+      await WorldEntriesRepository.getWorldEntryNotesContent(entryId);
+    return {
+      content: entry.notes_content
+        ? this.databaseToUint8Array(entry.notes_content)
+        : new Uint8Array(),
+    };
+  }
+
+  public static deleteWorldEntry(entryId: string): Promise<void> {
+    return WorldEntriesRepository.deleteWorldEntry(entryId);
+  }
+
+  // Both world buckets use the <worldId>/<entryId>/<filename> convention;
+  // storage policies check world_role() against the first path segment.
+  public static uploadWorldEntryImage(
+    worldId: string,
+    entryId: string,
+    image: File,
+  ): Promise<{ filename: string; url: string }> {
+    const filename = `${new Date().getTime()}_${image.name}`;
+    const renamedImage = StorageRepository.renameFile(image, filename);
+    return StorageRepository.storeImage(
+      "world_entry_images",
+      `${worldId}/${entryId}`,
+      renamedImage,
+    ).then((url) => ({ filename, url }));
+  }
+
+  public static deleteWorldEntryImage(
+    worldId: string,
+    entryId: string,
+    filename: string,
+  ): Promise<void> {
+    return StorageRepository.deleteImage(
+      "world_entry_images",
+      `${worldId}/${entryId}`,
+      filename,
+    );
+  }
+
+  public static getWorldEntryImageUrl(
+    worldId: string,
+    entryId: string,
+    filename: string,
+  ): string {
+    return StorageRepository.getImageUrl(
+      "world_entry_images",
+      `${worldId}/${entryId}`,
+      filename,
+    );
+  }
+
+  public static uploadWorldMapBackground(
+    worldId: string,
+    entryId: string,
+    image: File,
+  ): Promise<{ filename: string; url: string }> {
+    const filename = `${new Date().getTime()}_${image.name}`;
+    const renamedImage = StorageRepository.renameFile(image, filename);
+    return StorageRepository.storeImage(
+      "world_map_backgrounds",
+      `${worldId}/${entryId}`,
+      renamedImage,
+    ).then((url) => ({ filename, url }));
+  }
+
+  public static deleteWorldMapBackground(
+    worldId: string,
+    entryId: string,
+    filename: string,
+  ): Promise<void> {
+    return StorageRepository.deleteImage(
+      "world_map_backgrounds",
+      `${worldId}/${entryId}`,
+      filename,
+    );
+  }
+
+  public static getWorldMapBackgroundUrl(
+    worldId: string,
+    entryId: string,
+    filename: string,
+  ): string {
+    return StorageRepository.getImageUrl(
+      "world_map_backgrounds",
+      `${worldId}/${entryId}`,
+      filename,
+    );
+  }
+
+  private static convertWorldEntryDTOToWorldEntry(
+    entry: WorldEntryDTO,
+  ): IWorldEntry {
+    let readPermissions: ReadPermissions;
+    switch (entry.read_permissions) {
+      case "only_author":
+        readPermissions = ReadPermissions.OnlyAuthor;
+        break;
+      case "only_guides":
+        readPermissions = ReadPermissions.OnlyGuides;
+        break;
+      case "all_players":
+        readPermissions = ReadPermissions.AllPlayers;
+        break;
+      case "guides_and_author":
+        readPermissions = ReadPermissions.GuidesAndAuthor;
+        break;
+      case "public":
+        readPermissions = ReadPermissions.Public;
+        break;
+      default:
+        readPermissions = ReadPermissions.OnlyAuthor;
+    }
+    let editPermissions: EditPermissions;
+    switch (entry.edit_permissions) {
+      case "only_author":
+        editPermissions = EditPermissions.OnlyAuthor;
+        break;
+      case "only_guides":
+        editPermissions = EditPermissions.OnlyGuides;
+        break;
+      case "guides_and_author":
+        editPermissions = EditPermissions.GuidesAndAuthor;
+        break;
+      case "all_players":
+        editPermissions = EditPermissions.AllPlayers;
+        break;
+      default:
+        editPermissions = EditPermissions.OnlyAuthor;
+    }
+
+    return {
+      id: entry.id,
+      worldId: entry.world_id,
+      categoryId: entry.category_id,
+      parentEntryId: entry.parent_entry_id,
+      name: entry.name,
+      icon: (entry.icon as unknown as IconDefinition) ?? null,
+      imageFilenames: entry.image_filenames ?? [],
+      fields:
+        entry.fields && typeof entry.fields === "object"
+          ? (entry.fields as Record<string, WorldEntryFieldValue>)
+          : {},
+      map: (entry.map as unknown as LocationMap) ?? null,
+      mapBackgroundFilename: entry.map_background_filename,
+      mapSettings:
+        (entry.map_settings as unknown as IWorldEntryMapSettings) ?? null,
+      readPermissions,
+      editPermissions,
+      authorId: entry.author_id,
+      createdAt: new Date(entry.created_at),
+      updatedAt: new Date(entry.updated_at),
+    };
+  }
+
+  private static uint8ArrayToDatabase(arr: Uint8Array): string {
+    return "\\x" + Buffer.from(arr).toString("hex");
+  }
+  private static databaseToUint8Array(str: string): Uint8Array {
+    return Buffer.from(str.slice(2), "hex");
+  }
+}

--- a/src/services/worldEntryGmData.service.ts
+++ b/src/services/worldEntryGmData.service.ts
@@ -1,0 +1,101 @@
+import { Buffer } from "buffer";
+
+import { Json } from "types/supabase-generated.type";
+
+import { RepositoryError } from "repositories/errors/RepositoryErrors";
+import {
+  WorldEntryGmDataDTO,
+  WorldEntryGmDataRepository,
+} from "repositories/worldEntryGmData.repository";
+
+import { WorldEntryFieldValue } from "./worldEntries.service";
+
+export interface IWorldEntryGmData {
+  entryId: string;
+  worldId: string;
+  fields: Record<string, WorldEntryFieldValue>;
+}
+
+export class WorldEntryGmDataService {
+  public static listenToWorldEntryGmData(
+    worldId: string,
+    onGmDataChanges: (
+      changedGmData: Record<string, IWorldEntryGmData>,
+      removedEntryIds: string[],
+      replaceState: boolean,
+    ) => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    return WorldEntryGmDataRepository.listenToWorldEntryGmData(
+      worldId,
+      (changedGmData, removedEntryIds, replaceState) =>
+        onGmDataChanges(
+          Object.fromEntries(
+            Object.entries(changedGmData).map(([entryId, gmData]) => [
+              entryId,
+              this.convertGmDataDTOToGmData(gmData),
+            ]),
+          ),
+          removedEntryIds,
+          replaceState,
+        ),
+      onError,
+    );
+  }
+
+  public static updateWorldEntryGmFields(
+    entryId: string,
+    worldId: string,
+    fields: Record<string, WorldEntryFieldValue>,
+  ): Promise<void> {
+    return WorldEntryGmDataRepository.upsertWorldEntryGmData({
+      entry_id: entryId,
+      world_id: worldId,
+      fields: fields as unknown as Json,
+    });
+  }
+
+  public static updateWorldEntryGmNotesContent(
+    entryId: string,
+    worldId: string,
+    content: Uint8Array,
+  ): Promise<void> {
+    return WorldEntryGmDataRepository.upsertWorldEntryGmData({
+      entry_id: entryId,
+      world_id: worldId,
+      gm_notes_content: this.uint8ArrayToDatabase(content),
+    });
+  }
+
+  public static async getWorldEntryGmNotesContent(
+    entryId: string,
+  ): Promise<{ content: Uint8Array }> {
+    const gmData =
+      await WorldEntryGmDataRepository.getWorldEntryGmNotesContent(entryId);
+    return {
+      content: gmData?.gm_notes_content
+        ? this.databaseToUint8Array(gmData.gm_notes_content)
+        : new Uint8Array(),
+    };
+  }
+
+  private static convertGmDataDTOToGmData(
+    gmData: WorldEntryGmDataDTO,
+  ): IWorldEntryGmData {
+    return {
+      entryId: gmData.entry_id,
+      worldId: gmData.world_id,
+      fields:
+        gmData.fields && typeof gmData.fields === "object"
+          ? (gmData.fields as Record<string, WorldEntryFieldValue>)
+          : {},
+    };
+  }
+
+  private static uint8ArrayToDatabase(arr: Uint8Array): string {
+    return "\\x" + Buffer.from(arr).toString("hex");
+  }
+  private static databaseToUint8Array(str: string): Uint8Array {
+    return Buffer.from(str.slice(2), "hex");
+  }
+}

--- a/src/services/worldPlayers.service.ts
+++ b/src/services/worldPlayers.service.ts
@@ -1,0 +1,94 @@
+import { RepositoryError } from "repositories/errors/RepositoryErrors";
+import {
+  WorldPlayerDTO,
+  WorldPlayersRepository,
+} from "repositories/worldPlayers.repository";
+
+// Explicit membership roles stored in world_players. Game members get
+// live-derived guide/player access without a membership row (see
+// WorldPermission); these roles only exist as explicit rows.
+export enum WorldPlayerRole {
+  Owner = "owner",
+  Editor = "editor",
+  Viewer = "viewer",
+}
+
+export interface IWorldPlayer {
+  worldId: string;
+  userId: string;
+  role: WorldPlayerRole;
+  createdAt: Date;
+}
+
+export class WorldPlayersService {
+  public static listenToWorldPlayers(
+    worldId: string,
+    onWorldPlayerChanges: (
+      changedWorldPlayers: Record<string, IWorldPlayer>,
+      removedWorldPlayerIds: string[],
+      replaceState: boolean,
+    ) => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    return WorldPlayersRepository.listenToWorldPlayers(
+      worldId,
+      (changedPlayers, removedPlayerIds, replaceState) =>
+        onWorldPlayerChanges(
+          Object.fromEntries(
+            Object.entries(changedPlayers).map(([userId, player]) => [
+              userId,
+              this.convertWorldPlayerDTOToWorldPlayer(player),
+            ]),
+          ),
+          removedPlayerIds,
+          replaceState,
+        ),
+      onError,
+    );
+  }
+
+  public static addWorldPlayer(
+    worldId: string,
+    userId: string,
+    role: WorldPlayerRole,
+  ): Promise<void> {
+    return WorldPlayersRepository.addWorldPlayer(worldId, userId, role);
+  }
+
+  public static updateWorldPlayerRole(
+    worldId: string,
+    userId: string,
+    role: WorldPlayerRole,
+  ): Promise<void> {
+    return WorldPlayersRepository.updateWorldPlayerRole(worldId, userId, role);
+  }
+
+  public static removeWorldPlayer(
+    worldId: string,
+    userId: string,
+  ): Promise<void> {
+    return WorldPlayersRepository.removeWorldPlayer(worldId, userId);
+  }
+
+  private static convertWorldPlayerDTOToWorldPlayer(
+    player: WorldPlayerDTO,
+  ): IWorldPlayer {
+    let role: WorldPlayerRole;
+    switch (player.role) {
+      case "owner":
+        role = WorldPlayerRole.Owner;
+        break;
+      case "editor":
+        role = WorldPlayerRole.Editor;
+        break;
+      default:
+        role = WorldPlayerRole.Viewer;
+    }
+    return {
+      worldId: player.world_id,
+      userId: player.user_id,
+      role,
+      createdAt: new Date(player.created_at),
+    };
+  }
+}

--- a/src/services/worlds.service.ts
+++ b/src/services/worlds.service.ts
@@ -1,0 +1,89 @@
+import { RepositoryError } from "repositories/errors/RepositoryErrors";
+import { WorldPermission } from "repositories/shared.types";
+import { WorldDTO, WorldsRepository } from "repositories/worlds.repository";
+
+export interface IWorld {
+  id: string;
+  name: string;
+  description: string | null;
+  // Package-qualified setting key ("<packageId>/<settingKey>") chosen at
+  // creation; drives truths seeding and the binding picker's default scope.
+  settingKey: string | null;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class WorldsService {
+  public static async getWorld(worldId: string): Promise<IWorld> {
+    const world = await WorldsRepository.getWorld(worldId);
+    return this.convertWorldDTOToWorld(world);
+  }
+
+  public static listenToWorld(
+    worldId: string,
+    onWorld: (world: IWorld) => void,
+    onWorldDeleted: () => void,
+    onError: (error: RepositoryError) => void,
+  ): () => void {
+    return WorldsRepository.listenToWorld(
+      worldId,
+      (world) => onWorld(this.convertWorldDTOToWorld(world)),
+      onWorldDeleted,
+      onError,
+    );
+  }
+
+  public static async getUsersWorlds(): Promise<Record<string, IWorld>> {
+    const worlds = await WorldsRepository.getUsersWorlds();
+    return Object.fromEntries(
+      worlds.map((world) => [world.id, this.convertWorldDTOToWorld(world)]),
+    );
+  }
+
+  public static createWorld(
+    name: string,
+    description?: string,
+    settingKey?: string,
+  ): Promise<string> {
+    return WorldsRepository.createWorld(
+      name,
+      description ?? null,
+      settingKey ?? null,
+    );
+  }
+
+  public static updateWorldName(worldId: string, name: string): Promise<void> {
+    return WorldsRepository.updateWorld(worldId, { name });
+  }
+
+  public static updateWorldDescription(
+    worldId: string,
+    description: string | null,
+  ): Promise<void> {
+    return WorldsRepository.updateWorld(worldId, { description });
+  }
+
+  public static deleteWorld(worldId: string): Promise<void> {
+    return WorldsRepository.deleteWorld(worldId);
+  }
+
+  public static getWorldPermission(
+    worldId: string,
+    userId: string,
+  ): Promise<WorldPermission> {
+    return WorldsRepository.getWorldPermission(worldId, userId);
+  }
+
+  private static convertWorldDTOToWorld(world: WorldDTO): IWorld {
+    return {
+      id: world.id,
+      name: world.name,
+      description: world.description,
+      settingKey: world.setting_key,
+      createdBy: world.created_by,
+      createdAt: new Date(world.created_at),
+      updatedAt: new Date(world.updated_at),
+    };
+  }
+}

--- a/src/stores/users.worlds.store.ts
+++ b/src/stores/users.worlds.store.ts
@@ -1,0 +1,60 @@
+import deepEqual from "fast-deep-equal";
+import { useEffect } from "react";
+import { immer } from "zustand/middleware/immer";
+import { createWithEqualityFn } from "zustand/traditional";
+
+import { IWorld, WorldsService } from "services/worlds.service";
+
+import { useUID } from "./auth.store";
+
+interface UsersWorldsState {
+  worlds: Record<string, IWorld>;
+  loading: boolean;
+  error?: Error;
+}
+
+interface UsersWorldsActions {
+  loadUsersWorlds: () => Promise<void>;
+}
+
+const defaultValues: UsersWorldsState = {
+  worlds: {},
+  loading: true,
+};
+
+export const useUsersWorlds = createWithEqualityFn<
+  UsersWorldsState & UsersWorldsActions
+>()(
+  immer((set) => ({
+    ...defaultValues,
+
+    loadUsersWorlds: async () => {
+      try {
+        const worlds = await WorldsService.getUsersWorlds();
+        set((state) => {
+          state.loading = false;
+          state.worlds = worlds;
+          state.error = undefined;
+        });
+      } catch (e) {
+        console.error(e);
+        set((state) => {
+          state.loading = false;
+          state.error =
+            e instanceof Error ? e : new Error("Failed to load worlds");
+        });
+      }
+    },
+  })),
+  deepEqual,
+);
+
+export function useLoadUsersWorlds() {
+  const loadUsersWorlds = useUsersWorlds((state) => state.loadUsersWorlds);
+  const uid = useUID();
+  useEffect(() => {
+    if (uid) {
+      loadUsersWorlds();
+    }
+  }, [uid, loadUsersWorlds]);
+}

--- a/src/stores/world.store.ts
+++ b/src/stores/world.store.ts
@@ -1,0 +1,215 @@
+import deepEqual from "fast-deep-equal";
+import { useEffect } from "react";
+import { immer } from "zustand/middleware/immer";
+import { createWithEqualityFn } from "zustand/traditional";
+
+import { WorldPermission } from "repositories/shared.types";
+
+import {
+  IWorldPlayer,
+  WorldPlayerRole,
+  WorldPlayersService,
+} from "services/worldPlayers.service";
+import { IWorld, WorldsService } from "services/worlds.service";
+
+import { useUID } from "./auth.store";
+
+interface WorldStoreState {
+  worldId: string;
+  world: IWorld | null;
+  worldPlayers: Record<string, IWorldPlayer> | null;
+
+  // Mirrors world_role(): explicit membership roles take precedence over
+  // roles derived from linked games; fetched from the database so the
+  // client never re-implements the derivation.
+  worldPermission: WorldPermission | null;
+
+  loading: boolean;
+  error?: string;
+  worldDeleted: boolean;
+}
+
+interface WorldStoreActions {
+  listenToWorld: (worldId: string) => () => void;
+  loadWorldPermission: (worldId: string, uid: string | undefined) => void;
+
+  createWorld: (
+    name: string,
+    description?: string,
+    settingKey?: string,
+  ) => Promise<string>;
+  updateWorldName: (worldId: string, name: string) => Promise<void>;
+  updateWorldDescription: (
+    worldId: string,
+    description: string | null,
+  ) => Promise<void>;
+  deleteWorld: (worldId: string) => Promise<void>;
+
+  addWorldPlayer: (
+    worldId: string,
+    userId: string,
+    role: WorldPlayerRole,
+  ) => Promise<void>;
+  updateWorldPlayerRole: (
+    worldId: string,
+    userId: string,
+    role: WorldPlayerRole,
+  ) => Promise<void>;
+  removeWorldPlayer: (worldId: string, userId: string) => Promise<void>;
+}
+
+const defaultWorldStoreState: WorldStoreState = {
+  worldId: "",
+  world: null,
+  worldPlayers: null,
+  worldPermission: null,
+  loading: true,
+  worldDeleted: false,
+};
+
+export const useWorldStore = createWithEqualityFn<
+  WorldStoreState & WorldStoreActions
+>()(
+  immer((set) => ({
+    ...defaultWorldStoreState,
+
+    listenToWorld: (worldId: string) => {
+      set((state) => {
+        state.worldId = worldId;
+      });
+
+      const worldUnsubscribe = WorldsService.listenToWorld(
+        worldId,
+        (world) => {
+          set((state) => {
+            state.world = world;
+            state.loading = false;
+            state.error = undefined;
+          });
+        },
+        () => {
+          set((state) => {
+            state.worldDeleted = true;
+            state.loading = false;
+          });
+        },
+        (error) => {
+          console.error(error);
+          set((state) => {
+            state.loading = false;
+            state.error = "Failed to load world";
+          });
+        },
+      );
+
+      const worldPlayersUnsubscribe = WorldPlayersService.listenToWorldPlayers(
+        worldId,
+        (changedPlayers, removedPlayerIds, replaceState) => {
+          set((state) => {
+            if (replaceState) {
+              state.worldPlayers = changedPlayers;
+            } else {
+              state.worldPlayers = {
+                ...state.worldPlayers,
+                ...changedPlayers,
+              };
+              removedPlayerIds.forEach((userId) => {
+                delete state.worldPlayers?.[userId];
+              });
+            }
+          });
+        },
+        () => {},
+      );
+
+      return () => {
+        set((state) => ({
+          ...state,
+          ...defaultWorldStoreState,
+        }));
+        worldUnsubscribe();
+        worldPlayersUnsubscribe();
+      };
+    },
+
+    loadWorldPermission: (worldId, uid) => {
+      if (!uid) {
+        set((state) => {
+          state.worldPermission = WorldPermission.None;
+        });
+        return;
+      }
+      WorldsService.getWorldPermission(worldId, uid)
+        .then((permission) => {
+          set((state) => {
+            // Ignore stale responses after switching worlds
+            if (state.worldId === worldId) {
+              state.worldPermission = permission;
+            }
+          });
+        })
+        .catch((error) => {
+          console.error(error);
+          set((state) => {
+            if (state.worldId === worldId) {
+              state.worldPermission = WorldPermission.None;
+            }
+          });
+        });
+    },
+
+    createWorld: (name, description, settingKey) => {
+      return WorldsService.createWorld(name, description, settingKey);
+    },
+    updateWorldName: (worldId, name) => {
+      return WorldsService.updateWorldName(worldId, name);
+    },
+    updateWorldDescription: (worldId, description) => {
+      return WorldsService.updateWorldDescription(worldId, description);
+    },
+    deleteWorld: (worldId) => {
+      return WorldsService.deleteWorld(worldId);
+    },
+
+    addWorldPlayer: (worldId, userId, role) => {
+      return WorldPlayersService.addWorldPlayer(worldId, userId, role);
+    },
+    updateWorldPlayerRole: (worldId, userId, role) => {
+      return WorldPlayersService.updateWorldPlayerRole(worldId, userId, role);
+    },
+    removeWorldPlayer: (worldId, userId) => {
+      return WorldPlayersService.removeWorldPlayer(worldId, userId);
+    },
+  })),
+  deepEqual,
+);
+
+export function useListenToWorld(worldId: string | undefined) {
+  const uid = useUID();
+
+  const listenToWorld = useWorldStore((state) => state.listenToWorld);
+  const loadWorldPermission = useWorldStore(
+    (state) => state.loadWorldPermission,
+  );
+  const worldPlayers = useWorldStore((state) => state.worldPlayers);
+
+  useEffect(() => {
+    if (worldId) {
+      return listenToWorld(worldId);
+    }
+  }, [worldId, listenToWorld]);
+
+  // Refresh the derived role whenever membership changes (covers role edits
+  // for the current user; game-link changes surface on the next mount).
+  useEffect(() => {
+    if (worldId) {
+      loadWorldPermission(worldId, uid);
+    }
+  }, [worldId, uid, worldPlayers, loadWorldPermission]);
+}
+
+export function useWorldPermission(): WorldPermission {
+  return useWorldStore(
+    (state) => state.worldPermission ?? WorldPermission.None,
+  );
+}

--- a/src/stores/worldCategories.store.ts
+++ b/src/stores/worldCategories.store.ts
@@ -1,0 +1,119 @@
+import deepEqual from "fast-deep-equal";
+import { useEffect } from "react";
+import { immer } from "zustand/middleware/immer";
+import { createWithEqualityFn } from "zustand/traditional";
+
+import { IconDefinition } from "types/Icon.type";
+
+import {
+  FieldDefinition,
+  IWorldCategory,
+  WorldCategoriesService,
+} from "services/worldCategories.service";
+
+interface WorldCategoriesStoreState {
+  categories: Record<string, IWorldCategory>;
+  loading: boolean;
+  error?: string;
+}
+
+interface WorldCategoriesStoreActions {
+  listenToWorldCategories: (worldId: string) => () => void;
+
+  createCategory: (
+    worldId: string,
+    category: {
+      name: string;
+      icon?: IconDefinition;
+      sortOrder: number;
+      supportsHierarchy?: boolean;
+      supportsMap?: boolean;
+      supportsBonds?: boolean;
+      fieldDefinitions?: FieldDefinition[];
+    },
+  ) => Promise<string>;
+  updateCategory: (
+    categoryId: string,
+    category: Partial<Omit<IWorldCategory, "id" | "worldId">>,
+  ) => Promise<void>;
+  deleteCategory: (categoryId: string) => Promise<void>;
+
+  reset: () => void;
+}
+
+const defaultWorldCategoriesState: WorldCategoriesStoreState = {
+  categories: {},
+  loading: true,
+};
+
+export const useWorldCategoriesStore = createWithEqualityFn<
+  WorldCategoriesStoreState & WorldCategoriesStoreActions
+>()(
+  immer((set) => ({
+    ...defaultWorldCategoriesState,
+
+    listenToWorldCategories: (worldId) => {
+      return WorldCategoriesService.listenToWorldCategories(
+        worldId,
+        (changedCategories, removedCategoryIds, replaceState) => {
+          set((state) => {
+            if (replaceState) {
+              state.categories = changedCategories;
+            } else {
+              state.categories = {
+                ...state.categories,
+                ...changedCategories,
+              };
+              removedCategoryIds.forEach((categoryId) => {
+                delete state.categories[categoryId];
+              });
+            }
+            state.loading = false;
+            state.error = undefined;
+          });
+        },
+        (error) => {
+          console.error(error);
+          set((state) => {
+            state.loading = false;
+            state.error = error.message;
+          });
+        },
+      );
+    },
+
+    createCategory: (worldId, category) => {
+      return WorldCategoriesService.addWorldCategory(worldId, category);
+    },
+    updateCategory: (categoryId, category) => {
+      return WorldCategoriesService.updateWorldCategory(categoryId, category);
+    },
+    deleteCategory: (categoryId) => {
+      return WorldCategoriesService.deleteWorldCategory(categoryId);
+    },
+
+    reset: () => {
+      set((store) => ({ ...store, ...defaultWorldCategoriesState }));
+    },
+  })),
+  deepEqual,
+);
+
+export function useListenToWorldCategories(worldId: string | undefined) {
+  const listenToWorldCategories = useWorldCategoriesStore(
+    (store) => store.listenToWorldCategories,
+  );
+  const resetStore = useWorldCategoriesStore((store) => store.reset);
+
+  useEffect(() => {
+    if (worldId) {
+      return listenToWorldCategories(worldId);
+    }
+  }, [worldId, listenToWorldCategories]);
+
+  useEffect(() => {
+    return () => {
+      resetStore();
+    };
+  }, [worldId, resetStore]);
+}

--- a/src/stores/worldEntries.store.ts
+++ b/src/stores/worldEntries.store.ts
@@ -1,0 +1,345 @@
+import deepEqual from "fast-deep-equal";
+import { useEffect } from "react";
+import { immer } from "zustand/middleware/immer";
+import { createWithEqualityFn } from "zustand/traditional";
+
+import {
+  EditPermissions,
+  ReadPermissions,
+  WorldPermission,
+} from "repositories/shared.types";
+
+import {
+  IWorldEntry,
+  IWorldEntryNotesContent,
+  WorldEntriesService,
+} from "services/worldEntries.service";
+import {
+  IWorldEntryGmData,
+  WorldEntryGmDataService,
+} from "services/worldEntryGmData.service";
+
+import { useUID } from "./auth.store";
+import { useWorldStore } from "./world.store";
+
+interface EntryPermissions {
+  canEdit: boolean;
+  canDelete: boolean;
+  canChangePermissions: boolean;
+}
+
+interface WorldEntriesStoreState {
+  entryState: {
+    entries: Record<string, IWorldEntry>;
+    permissions: Record<string, EntryPermissions>;
+    loading: boolean;
+    error?: string;
+  };
+  gmDataState: {
+    gmData: Record<string, IWorldEntryGmData>;
+    loading: boolean;
+    error?: string;
+  };
+}
+
+interface WorldEntriesStoreActions {
+  listenToWorldEntries: (
+    uid: string | undefined,
+    worldId: string,
+    permission: WorldPermission,
+  ) => () => void;
+  listenToWorldEntryGmData: (worldId: string) => () => void;
+
+  createEntry: (
+    uid: string,
+    worldId: string,
+    categoryId: string,
+    name: string,
+    readPermissions: ReadPermissions,
+    editPermissions: EditPermissions,
+    parentEntryId?: string,
+  ) => Promise<string>;
+  updateEntry: (
+    entryId: string,
+    entry: Partial<
+      Omit<
+        IWorldEntry,
+        "id" | "worldId" | "authorId" | "createdAt" | "updatedAt"
+      >
+    >,
+  ) => Promise<void>;
+  deleteEntry: (entryId: string) => Promise<void>;
+
+  getEntryNotesContent: (entryId: string) => Promise<IWorldEntryNotesContent>;
+  updateEntryNotesContent: (
+    entryId: string,
+    content: Uint8Array,
+  ) => Promise<void>;
+
+  updateEntryGmFields: (
+    entryId: string,
+    worldId: string,
+    fields: IWorldEntryGmData["fields"],
+  ) => Promise<void>;
+  getEntryGmNotesContent: (entryId: string) => Promise<{ content: Uint8Array }>;
+  updateEntryGmNotesContent: (
+    entryId: string,
+    worldId: string,
+    content: Uint8Array,
+  ) => Promise<void>;
+
+  uploadEntryImage: (
+    worldId: string,
+    entryId: string,
+    image: File,
+  ) => Promise<{ filename: string; url: string }>;
+  deleteEntryImage: (
+    worldId: string,
+    entryId: string,
+    filename: string,
+  ) => Promise<void>;
+
+  reset: () => void;
+}
+
+const defaultWorldEntriesState: WorldEntriesStoreState = {
+  entryState: {
+    entries: {},
+    permissions: {},
+    loading: true,
+  },
+  gmDataState: {
+    gmData: {},
+    loading: true,
+  },
+};
+
+export const useWorldEntriesStore = createWithEqualityFn<
+  WorldEntriesStoreState & WorldEntriesStoreActions
+>()(
+  immer((set) => ({
+    ...defaultWorldEntriesState,
+
+    listenToWorldEntries: (uid, worldId, permission) => {
+      return WorldEntriesService.listenToWorldEntries(
+        uid,
+        worldId,
+        permission,
+        (changedEntries, removedEntryIds, replaceState) => {
+          set((store) => {
+            if (replaceState) {
+              store.entryState.entries = changedEntries;
+              store.entryState.permissions = {};
+            } else {
+              store.entryState.entries = {
+                ...store.entryState.entries,
+                ...changedEntries,
+              };
+              removedEntryIds.forEach((entryId) => {
+                delete store.entryState.entries[entryId];
+                delete store.entryState.permissions[entryId];
+              });
+            }
+            Object.entries(changedEntries).forEach(([entryId, entry]) => {
+              store.entryState.permissions[entryId] = getEntryPermissions(
+                entry.editPermissions,
+                entry.authorId,
+                uid,
+                permission,
+              );
+            });
+            store.entryState.loading = false;
+            store.entryState.error = undefined;
+          });
+        },
+        (error) => {
+          set((store) => {
+            store.entryState.loading = false;
+            store.entryState.error = error.message;
+          });
+        },
+      );
+    },
+
+    listenToWorldEntryGmData: (worldId) => {
+      return WorldEntryGmDataService.listenToWorldEntryGmData(
+        worldId,
+        (changedGmData, removedEntryIds, replaceState) => {
+          set((store) => {
+            if (replaceState) {
+              store.gmDataState.gmData = changedGmData;
+            } else {
+              store.gmDataState.gmData = {
+                ...store.gmDataState.gmData,
+                ...changedGmData,
+              };
+              removedEntryIds.forEach((entryId) => {
+                delete store.gmDataState.gmData[entryId];
+              });
+            }
+            store.gmDataState.loading = false;
+            store.gmDataState.error = undefined;
+          });
+        },
+        (error) => {
+          set((store) => {
+            store.gmDataState.loading = false;
+            store.gmDataState.error = error.message;
+          });
+        },
+      );
+    },
+
+    createEntry: (
+      uid,
+      worldId,
+      categoryId,
+      name,
+      readPermissions,
+      editPermissions,
+      parentEntryId,
+    ) => {
+      return WorldEntriesService.addWorldEntry(
+        uid,
+        worldId,
+        categoryId,
+        name,
+        readPermissions,
+        editPermissions,
+        parentEntryId,
+      );
+    },
+    updateEntry: (entryId, entry) => {
+      return WorldEntriesService.updateWorldEntry(entryId, entry);
+    },
+    deleteEntry: (entryId) => {
+      return WorldEntriesService.deleteWorldEntry(entryId);
+    },
+
+    getEntryNotesContent: (entryId) => {
+      return WorldEntriesService.getWorldEntryNotesContent(entryId);
+    },
+    updateEntryNotesContent: (entryId, content) => {
+      return WorldEntriesService.updateWorldEntryNotesContent(entryId, content);
+    },
+
+    updateEntryGmFields: (entryId, worldId, fields) => {
+      return WorldEntryGmDataService.updateWorldEntryGmFields(
+        entryId,
+        worldId,
+        fields,
+      );
+    },
+    getEntryGmNotesContent: (entryId) => {
+      return WorldEntryGmDataService.getWorldEntryGmNotesContent(entryId);
+    },
+    updateEntryGmNotesContent: (entryId, worldId, content) => {
+      return WorldEntryGmDataService.updateWorldEntryGmNotesContent(
+        entryId,
+        worldId,
+        content,
+      );
+    },
+
+    uploadEntryImage: (worldId, entryId, image) => {
+      return WorldEntriesService.uploadWorldEntryImage(worldId, entryId, image);
+    },
+    deleteEntryImage: (worldId, entryId, filename) => {
+      return WorldEntriesService.deleteWorldEntryImage(
+        worldId,
+        entryId,
+        filename,
+      );
+    },
+
+    reset: () => {
+      set((store) => ({ ...store, ...defaultWorldEntriesState }));
+    },
+  })),
+  deepEqual,
+);
+
+export function useListenToWorldEntries(worldId: string | undefined) {
+  const uid = useUID();
+  const worldPermission = useWorldStore((store) => store.worldPermission);
+
+  const listenToWorldEntries = useWorldEntriesStore(
+    (store) => store.listenToWorldEntries,
+  );
+  const listenToWorldEntryGmData = useWorldEntriesStore(
+    (store) => store.listenToWorldEntryGmData,
+  );
+  const resetStore = useWorldEntriesStore((store) => store.reset);
+
+  useEffect(() => {
+    if (worldId && worldPermission) {
+      return listenToWorldEntries(uid, worldId, worldPermission);
+    }
+  }, [worldId, uid, worldPermission, listenToWorldEntries]);
+
+  useEffect(() => {
+    // RLS limits gm data to owner/editor/guide; don't subscribe for others
+    if (worldId && worldPermission && isGuideEquivalent(worldPermission)) {
+      return listenToWorldEntryGmData(worldId);
+    }
+  }, [worldId, worldPermission, listenToWorldEntryGmData]);
+
+  useEffect(() => {
+    return () => {
+      resetStore();
+    };
+  }, [worldId, resetStore]);
+}
+
+export function isGuideEquivalent(permission: WorldPermission): boolean {
+  return (
+    permission === WorldPermission.Owner ||
+    permission === WorldPermission.Editor ||
+    permission === WorldPermission.Guide
+  );
+}
+
+// Mirrors the world_entries update/delete policies: explicit viewers are
+// read-only, guides/editors/owners can always delete, and edit access follows
+// the entry's edit_permissions.
+function getEntryPermissions(
+  editPermissions: EditPermissions,
+  authorId: string,
+  uid: string | undefined,
+  worldPermission: WorldPermission,
+): EntryPermissions {
+  if (
+    !uid ||
+    worldPermission === WorldPermission.None ||
+    worldPermission === WorldPermission.Viewer
+  ) {
+    return { canEdit: false, canDelete: false, canChangePermissions: false };
+  }
+
+  const isAuthor = authorId === uid;
+  const isGuide = isGuideEquivalent(worldPermission);
+
+  let canEdit: boolean;
+  switch (editPermissions) {
+    case EditPermissions.AllPlayers:
+      canEdit = true;
+      break;
+    case EditPermissions.GuidesAndAuthor:
+      canEdit = isAuthor || isGuide;
+      break;
+    case EditPermissions.OnlyGuides:
+      canEdit = isGuide;
+      break;
+    case EditPermissions.OnlyAuthor:
+      canEdit = isAuthor;
+      break;
+    default:
+      canEdit = false;
+  }
+
+  return {
+    canEdit,
+    canDelete: isAuthor || isGuide,
+    canChangePermissions: isAuthor || isGuide,
+  };
+}

--- a/src/types/supabase-generated.type.ts
+++ b/src/types/supabase-generated.type.ts
@@ -904,6 +904,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      create_world: {
+        Args: {
+          p_name: string
+          p_description?: string
+          p_setting_key?: string
+        }
+        Returns: string
+      }
       world_role: {
         Args: { p_world_id: string; p_uid: string }
         Returns: string

--- a/supabase/migrations/20260702000000_changes.sql
+++ b/supabase/migrations/20260702000000_changes.sql
@@ -110,3 +110,36 @@ with check (
         else false
     end
 );
+
+
+-- ---------------------------------------------------------------------------
+-- Fix infinite recursion in the worlds / world_players select policies
+--
+-- The world_players select policy referenced world_players in its own USING
+-- clause, which Postgres rejects at query time (42P17), and the worlds select
+-- policy hit the same recursion through its world_players subquery — every
+-- read of either table failed. world_role() is SECURITY DEFINER, so its
+-- internal membership lookups bypass RLS and cannot recurse.
+-- ---------------------------------------------------------------------------
+
+drop policy "World members and linked game players can read worlds" on "public"."worlds";
+
+create policy "World members and linked game players can read worlds"
+on "public"."worlds"
+as permissive
+for select
+to authenticated
+using (
+    public.world_role(worlds.id, ( select auth.uid() )) <> 'none'
+);
+
+drop policy "World members can read world_players" on "public"."world_players";
+
+create policy "World members can read world_players"
+on "public"."world_players"
+as permissive
+for select
+to authenticated
+using (
+    public.world_role(world_players.world_id, ( select auth.uid() )) <> 'none'
+);

--- a/supabase/migrations/20260702000000_changes.sql
+++ b/supabase/migrations/20260702000000_changes.sql
@@ -1,0 +1,112 @@
+-- ---------------------------------------------------------------------------
+-- create_world() helper function
+--
+-- The world_players insert policy is owner-only, but a world's creator has no
+-- role until their owner row exists ("world_role() returns 'none'"), so the
+-- initial owner row can never be inserted under RLS. This SECURITY DEFINER
+-- function creates the world and its owner membership row atomically instead
+-- of loosening the policy.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.create_world(
+    p_name text,
+    p_description text default null,
+    p_setting_key text default null
+)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+declare
+    v_uid uuid := auth.uid();
+    v_world_id uuid;
+begin
+    if v_uid is null then
+        raise exception 'Must be authenticated to create a world';
+    end if;
+
+    insert into public.worlds (name, description, setting_key, created_by)
+    values (p_name, p_description, p_setting_key, v_uid)
+    returning id into v_world_id;
+
+    insert into public.world_players (world_id, user_id, role)
+    values (v_world_id, v_uid, 'owner');
+
+    return v_world_id;
+end;
+$function$;
+
+revoke execute on function public.create_world(text, text, text) from public;
+revoke execute on function public.create_world(text, text, text) from anon;
+grant execute on function public.create_world(text, text, text) to authenticated;
+grant execute on function public.create_world(text, text, text) to service_role;
+
+
+-- ---------------------------------------------------------------------------
+-- Exclude explicit 'viewer' members from world_entries writes
+--
+-- The original insert policy and the 'all_players' edit branch accepted any
+-- world_players row, so an explicitly-invited read-only viewer could create
+-- and edit entries. Viewers are read-only (the storage write policies already
+-- exclude them); require a writing role instead of bare membership.
+-- ---------------------------------------------------------------------------
+
+drop policy "World members can insert world_entries" on "public"."world_entries";
+
+create policy "World members can insert world_entries"
+on "public"."world_entries"
+as permissive
+for insert
+to authenticated
+with check (
+    world_entries.author_id = ( select auth.uid() )
+    and public.world_role(world_entries.world_id, ( select auth.uid() ))
+        in ('owner', 'editor', 'guide', 'player')
+);
+
+drop policy "World entries are writable per edit_permissions" on "public"."world_entries";
+
+create policy "World entries are writable per edit_permissions"
+on "public"."world_entries"
+as permissive
+for update
+to authenticated
+using (
+    case world_entries.edit_permissions
+        when 'all_players' then (
+            public.world_role(world_entries.world_id, ( select auth.uid() ))
+                in ('owner', 'editor', 'guide', 'player')
+        )
+        when 'guides_and_author' then (
+            world_entries.author_id = ( select auth.uid() )
+            or public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_guides' then (
+            public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_author' then (
+            world_entries.author_id = ( select auth.uid() )
+        )
+        else false
+    end
+)
+with check (
+    case world_entries.edit_permissions
+        when 'all_players' then (
+            public.world_role(world_entries.world_id, ( select auth.uid() ))
+                in ('owner', 'editor', 'guide', 'player')
+        )
+        when 'guides_and_author' then (
+            world_entries.author_id = ( select auth.uid() )
+            or public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_guides' then (
+            public.world_role(world_entries.world_id, ( select auth.uid() )) in ('owner', 'editor', 'guide')
+        )
+        when 'only_author' then (
+            world_entries.author_id = ( select auth.uid() )
+        )
+        else false
+    end
+);


### PR DESCRIPTION
## Summary

Implements **W2 (data layer)** from the [iron-link-parity plan](https://github.com/scottbenton) on top of the merged worlds schema (#187), following the notes/game stack layering (repository → service → zustand store):

- **Repositories**: `worlds`, `worldPlayers`, `worldCategories`, `worldEntries`, `worldEntryGmData` — realtime subscriptions via `createSubscription`, client-side `read_permissions` filtering that mirrors the RLS policies, and on-demand fetching for the heavy Yjs byte columns (`notes_content`, `gm_notes_content`), matching how notes work.
- **Services**: DTO → domain conversion (`IWorld`, `IWorldPlayer`, `IWorldCategory` with `FieldDefinition`/`OracleBinding` from 01-worlds.md, `IWorldEntry`), plus storage helpers for both world buckets using the `<worldId>/<entryId>/<filename>` convention.
- **Stores**: `users.worlds` (world select), `world` (world + players + `WorldPermission` fetched from the `world_role()` RPC so the client never re-implements the role derivation), `worldCategories`, `worldEntries` (entries + GM data + per-entry write permissions modeled on the notes store).

## Migration fixes

The new migration also fixes two issues found in the original worlds migration:

1. **World creation was impossible**: the `world_players` insert policy is owner-only, but the creator has no role until their owner row exists, so the initial owner row could never be inserted. Added a `create_world()` SECURITY DEFINER RPC that inserts the world + owner row atomically.
2. **Read-only viewers could write entries**: the `world_entries` insert policy and the `all_players` edit branch accepted *any* `world_players` member, including explicit `viewer` rows (the storage write policies already excluded viewers). Both policies now require a writing role.

`src/types/supabase-generated.type.ts` was updated by hand for the new `create_world` function — worth re-running `supabase gen types` against a reset local DB to confirm it matches.

## Verification

- `tsc -b` clean
- `eslint .` clean (one pre-existing warning in `PortraitAvatarDisplay.tsx`)
- `vitest --run`: 58/58 passing
- Prettier clean on all new files

No UI in this PR — the W3 world CRUD pages + effective-playset resolver stack on top of this branch next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)