### PR TITLE
feat(worlds): world select/create/overview pages + effective-playset resolver (W3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,10 @@ const GameCreatePage = lazy(
   () => import("./pages/games/create/CreateGamePage"),
 );
 const WorldSelectPage = lazy(() => import("./pages/worlds/WorldSelectPage"));
+const WorldCreatePage = lazy(
+  () => import("./pages/worlds/create/CreateWorldPage"),
+);
+const WorldPage = lazy(() => import("./pages/worlds/worldPage/WorldPage"));
 const HomebrewSelectPage = lazy(
   () => import("./pages/homebrew/HomebrewSelectPage"),
 );
@@ -58,6 +62,8 @@ export function App() {
                 <Route path="/games/create" Component={GameCreatePage} />
                 <Route path="/join/:inviteKey" Component={GameJoinPage} />
                 <Route path="/worlds" Component={WorldSelectPage} />
+                <Route path="/worlds/create" Component={WorldCreatePage} />
+                <Route path="/worlds/:worldId" Component={WorldPage} />
                 <Route path="/homebrew" Component={HomebrewSelectPage} />
                 <Route path="/auth" Component={AuthPage} />
                 <Route path="*" Component={Page404} />

--- a/src/hooks/useSendPageViewEvents.ts
+++ b/src/hooks/useSendPageViewEvents.ts
@@ -11,6 +11,8 @@ export enum PageCategory {
   GameSelect = "game_select",
   GameCreate = "game_create",
   WorldSelect = "world_select",
+  WorldCreate = "world_create",
+  World = "world",
   HomebrewSelect = "homebrew_select",
   Auth = "auth",
   GameJoin = "game_join",

--- a/src/lib/__tests__/effectivePlayset.test.ts
+++ b/src/lib/__tests__/effectivePlayset.test.ts
@@ -1,0 +1,320 @@
+import { Datasworn } from "@datasworn/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  LinkedGamePlayset,
+  buildOracleReplacementMap,
+  computeEffectivePlayset,
+  getBindingDivergence,
+  getGameActivePackageIds,
+  getPackageIdFromDataswornId,
+  resolveOracleBinding,
+} from "../effectivePlayset";
+
+function makeGame(
+  rulesets: Record<string, boolean>,
+  expansions: Record<string, Record<string, boolean>> = {},
+  playset: LinkedGamePlayset["playset"] = {},
+): LinkedGamePlayset {
+  return { rulesets, expansions, playset };
+}
+
+function makeOracle(id: string, replaces?: string[]): Datasworn.OracleRollable {
+  return {
+    _id: id,
+    type: "oracle_rollable",
+    replaces,
+  } as unknown as Datasworn.OracleRollable;
+}
+
+function makeCollection(
+  id: string,
+  contents: Record<string, Datasworn.OracleRollable>,
+  replaces?: string[],
+): Datasworn.OracleCollection {
+  return {
+    _id: id,
+    type: "oracle_collection",
+    contents,
+    replaces,
+  } as unknown as Datasworn.OracleCollection;
+}
+
+// Minimal tree: base ruleset with a names collection, expansion replacing
+// the given_name oracle.
+const baseNamesGiven = makeOracle("oracle_rollable:base/names/given");
+const basePackage = {
+  _id: "base",
+  type: "ruleset",
+  oracles: {
+    names: makeCollection("oracle_collection:base/names", {
+      given: baseNamesGiven,
+    }),
+  },
+} as unknown as Datasworn.RulesPackage;
+
+const expNamesGiven = makeOracle("oracle_rollable:exp/names/given", [
+  "oracle_rollable:base/names/given",
+]);
+const expPackage = {
+  _id: "exp",
+  type: "expansion",
+  oracles: {
+    names: makeCollection("oracle_collection:exp/names", {
+      given: expNamesGiven,
+    }),
+  },
+} as unknown as Datasworn.RulesPackage;
+
+const tree: Record<string, Datasworn.RulesPackage> = {
+  base: basePackage,
+  exp: expPackage,
+};
+
+describe("getGameActivePackageIds", () => {
+  it("returns active rulesets and their active expansions", () => {
+    const game = makeGame(
+      { base: true, other: false },
+      { base: { exp: true, exp2: false }, other: { ignored: true } },
+    );
+    expect(getGameActivePackageIds(game)).toEqual(["base", "exp"]);
+  });
+});
+
+describe("getPackageIdFromDataswornId", () => {
+  it("extracts the package id", () => {
+    expect(
+      getPackageIdFromDataswornId("oracle_rollable:base/names/given"),
+    ).toBe("base");
+    expect(getPackageIdFromDataswornId("not-an-id")).toBeUndefined();
+  });
+});
+
+describe("computeEffectivePlayset", () => {
+  it("uses standalone packages with no exclusions when no games are linked", () => {
+    const playset = computeEffectivePlayset([], ["base", "base", "exp"]);
+    expect(playset.packageIds.sort()).toEqual(["base", "exp"]);
+    expect(playset.isOracleIncluded("base", "oracle_rollable:base/x")).toBe(
+      true,
+    );
+    expect(
+      playset.isOracleIncluded("missing", "oracle_rollable:missing/x"),
+    ).toBe(false);
+  });
+
+  it("takes the union of linked games' packages", () => {
+    const playset = computeEffectivePlayset([
+      makeGame({ base: true }),
+      makeGame({ base: true }, { base: { exp: true } }),
+    ]);
+    expect(playset.packageIds.sort()).toEqual(["base", "exp"]);
+  });
+
+  it("absence of a package in one game is not a veto", () => {
+    const playset = computeEffectivePlayset([
+      makeGame({ base: true }),
+      makeGame({ base: true }, { base: { exp: true } }),
+    ]);
+    expect(
+      playset.isOracleIncluded("exp", "oracle_rollable:exp/names/given"),
+    ).toBe(true);
+  });
+
+  it("an explicit exclusion in every containing playset is respected", () => {
+    const playset = computeEffectivePlayset([
+      makeGame({ base: true }),
+      makeGame(
+        { base: true },
+        { base: { exp: true } },
+        {
+          excludes: {
+            oracles: { "oracle_rollable:exp/names/given": true },
+          },
+        },
+      ),
+    ]);
+    expect(
+      playset.isOracleIncluded("exp", "oracle_rollable:exp/names/given"),
+    ).toBe(false);
+  });
+
+  it("an exclusion in one game is overridden by inclusion in another game with the package", () => {
+    const playset = computeEffectivePlayset([
+      makeGame(
+        { base: true },
+        { base: { exp: true } },
+        {
+          excludes: {
+            oracles: { "oracle_rollable:exp/names/given": true },
+          },
+        },
+      ),
+      makeGame({ base: true }, { base: { exp: true } }),
+    ]);
+    expect(
+      playset.isOracleIncluded("exp", "oracle_rollable:exp/names/given"),
+    ).toBe(true);
+  });
+
+  it("respects oracle category exclusions on ancestors", () => {
+    const playset = computeEffectivePlayset([
+      makeGame(
+        { base: true },
+        {},
+        {
+          excludes: {
+            oracleCategories: { "oracle_collection:base/names": true },
+          },
+        },
+      ),
+    ]);
+    expect(
+      playset.isOracleIncluded("base", "oracle_rollable:base/names/given"),
+    ).toBe(false);
+    expect(
+      playset.isOracleIncluded("base", "oracle_rollable:base/other/oracle"),
+    ).toBe(true);
+  });
+});
+
+describe("buildOracleReplacementMap", () => {
+  it("applies oracle-level replaces when the replacing oracle is included", () => {
+    const playset = computeEffectivePlayset([
+      makeGame({ base: true }, { base: { exp: true } }),
+    ]);
+    const map = buildOracleReplacementMap(tree, playset);
+    expect(map["oracle_rollable:base/names/given"]).toBe(
+      "oracle_rollable:exp/names/given",
+    );
+  });
+
+  it("skips replacements when the replacing oracle is excluded everywhere", () => {
+    const playset = computeEffectivePlayset([
+      makeGame(
+        { base: true },
+        { base: { exp: true } },
+        {
+          excludes: {
+            oracles: { "oracle_rollable:exp/names/given": true },
+          },
+        },
+      ),
+    ]);
+    const map = buildOracleReplacementMap(tree, playset);
+    expect(map["oracle_rollable:base/names/given"]).toBeUndefined();
+  });
+
+  it("skips replacements from packages outside the effective playset", () => {
+    const playset = computeEffectivePlayset([makeGame({ base: true })]);
+    const map = buildOracleReplacementMap(tree, playset);
+    expect(map["oracle_rollable:base/names/given"]).toBeUndefined();
+  });
+
+  it("applies collection-level replaces member-by-member", () => {
+    const collectionReplacer = {
+      _id: "exp2",
+      type: "expansion",
+      oracles: {
+        names: makeCollection(
+          "oracle_collection:exp2/names",
+          { given: makeOracle("oracle_rollable:exp2/names/given") },
+          ["oracle_collection:base/names"],
+        ),
+      },
+    } as unknown as Datasworn.RulesPackage;
+
+    const playset = computeEffectivePlayset([
+      makeGame({ base: true }, { base: { exp2: true } }),
+    ]);
+    const map = buildOracleReplacementMap(
+      { base: basePackage, exp2: collectionReplacer },
+      playset,
+    );
+    expect(map["oracle_rollable:base/names/given"]).toBe(
+      "oracle_rollable:exp2/names/given",
+    );
+  });
+
+  it("tiebreaks deterministically when two packages replace the same oracle", () => {
+    const otherReplacer = {
+      _id: "aexp",
+      type: "expansion",
+      oracles: {
+        names: makeCollection("oracle_collection:aexp/names", {
+          given: makeOracle("oracle_rollable:aexp/names/given", [
+            "oracle_rollable:base/names/given",
+          ]),
+        }),
+      },
+    } as unknown as Datasworn.RulesPackage;
+
+    const playset = computeEffectivePlayset([
+      makeGame({ base: true }, { base: { exp: true, aexp: true } }),
+    ]);
+    const map = buildOracleReplacementMap(
+      { ...tree, aexp: otherReplacer },
+      playset,
+    );
+    expect(map["oracle_rollable:base/names/given"]).toBe(
+      "oracle_rollable:aexp/names/given",
+    );
+  });
+});
+
+describe("resolveOracleBinding and getBindingDivergence", () => {
+  const replacementMap = {
+    "oracle_rollable:base/names/given": "oracle_rollable:exp/names/given",
+  };
+
+  it("resolves through the replacement map", () => {
+    expect(
+      resolveOracleBinding(
+        {
+          oracleId: "oracle_rollable:base/names/given",
+          resolvedOracleId: "oracle_rollable:base/names/given",
+        },
+        replacementMap,
+      ),
+    ).toBe("oracle_rollable:exp/names/given");
+  });
+
+  it("exact bindings ignore replacements", () => {
+    expect(
+      resolveOracleBinding(
+        {
+          oracleId: "oracle_rollable:base/names/given",
+          resolvedOracleId: "oracle_rollable:base/names/given",
+          exact: true,
+        },
+        replacementMap,
+      ),
+    ).toBe("oracle_rollable:base/names/given");
+  });
+
+  it("reports divergence against the stored resolution", () => {
+    expect(
+      getBindingDivergence(
+        {
+          oracleId: "oracle_rollable:base/names/given",
+          resolvedOracleId: "oracle_rollable:base/names/given",
+        },
+        replacementMap,
+      ),
+    ).toEqual({
+      previousOracleId: "oracle_rollable:base/names/given",
+      nextOracleId: "oracle_rollable:exp/names/given",
+    });
+  });
+
+  it("returns null when the resolution has not changed", () => {
+    expect(
+      getBindingDivergence(
+        {
+          oracleId: "oracle_rollable:base/names/given",
+          resolvedOracleId: "oracle_rollable:exp/names/given",
+        },
+        replacementMap,
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/effectivePlayset.ts
+++ b/src/lib/effectivePlayset.ts
@@ -1,0 +1,224 @@
+import { Datasworn, IdParser } from "@datasworn/core";
+import { Primary } from "@datasworn/core/dist/StringId";
+
+import {
+  ExpansionConfig,
+  PlaysetConfig,
+  RulesetConfig,
+} from "repositories/game.repository";
+
+// The effective playset of a world (iron-link-parity 01-worlds.md):
+// derived at read time, persisted nowhere.
+//
+// - Linked games: the union of the games' playsets. A datasworn `replaces`
+//   applies iff the replacing oracle is included in at least one linked
+//   game's playset — a game *not having* a package is absence, not a veto;
+//   an explicit exclusion in a playset that has the package is an opinion.
+// - Standalone worlds: the setting's packages plus the packages referenced
+//   by existing bindings, with no exclusions.
+//
+// Bindings are pinned and concrete ({ packageId, oracleId }); resolution
+// applies at most one replacement step on top of the pinned id, and the
+// `exact` flag skips replacements entirely.
+
+export interface LinkedGamePlayset {
+  rulesets: RulesetConfig;
+  expansions: ExpansionConfig;
+  playset: PlaysetConfig;
+}
+
+export interface EffectivePlayset {
+  packageIds: string[];
+  isOracleIncluded: (packageId: string, oracleId: string) => boolean;
+}
+
+export function getGameActivePackageIds(game: LinkedGamePlayset): string[] {
+  const packageIds: string[] = [];
+  Object.entries(game.rulesets).forEach(([rulesetId, isActive]) => {
+    if (!isActive) return;
+    packageIds.push(rulesetId);
+    Object.entries(game.expansions[rulesetId] ?? {}).forEach(
+      ([expansionId, isExpansionActive]) => {
+        if (isExpansionActive) {
+          packageIds.push(expansionId);
+        }
+      },
+    );
+  });
+  return packageIds;
+}
+
+export function getPackageIdFromDataswornId(
+  dataswornId: string,
+): string | undefined {
+  return dataswornId.split(":")[1]?.split("/")[0];
+}
+
+function getAncestorCollectionIds(oracleId: string): string[] {
+  // "oracle_rollable:pkg/a/b/c" -> ["oracle_collection:pkg/a/b",
+  //                                 "oracle_collection:pkg/a"]
+  const path = oracleId.split(":")[1];
+  if (!path) return [];
+  const segments = path.split("/");
+  const ancestors: string[] = [];
+  // Stop before the bare package id — that is not a collection
+  for (let length = segments.length - 1; length >= 2; length--) {
+    ancestors.push(`oracle_collection:${segments.slice(0, length).join("/")}`);
+  }
+  return ancestors;
+}
+
+function isOracleExcludedByPlayset(
+  playset: PlaysetConfig,
+  oracleId: string,
+): boolean {
+  if (playset.excludes?.oracles?.[oracleId]) {
+    return true;
+  }
+  return getAncestorCollectionIds(oracleId).some(
+    (collectionId) => playset.excludes?.oracleCategories?.[collectionId],
+  );
+}
+
+export function computeEffectivePlayset(
+  linkedGames: LinkedGamePlayset[],
+  standalonePackageIds: string[] = [],
+): EffectivePlayset {
+  if (linkedGames.length === 0) {
+    const packageIds = Array.from(new Set(standalonePackageIds));
+    return {
+      packageIds,
+      isOracleIncluded: (packageId) => packageIds.includes(packageId),
+    };
+  }
+
+  const gamePackages = linkedGames.map((game) => ({
+    game,
+    packageIds: getGameActivePackageIds(game),
+  }));
+  const packageIds = Array.from(
+    new Set(gamePackages.flatMap(({ packageIds }) => packageIds)),
+  );
+
+  return {
+    packageIds,
+    isOracleIncluded: (packageId, oracleId) =>
+      gamePackages.some(
+        ({ game, packageIds }) =>
+          packageIds.includes(packageId) &&
+          !isOracleExcludedByPlayset(game.playset, oracleId),
+      ),
+  };
+}
+
+// Maps replaced oracle id -> replacing oracle id, considering only packages
+// in the effective playset and only replacements whose replacing oracle is
+// included in at least one linked playset. When two included oracles replace
+// the same id, the lexicographically smallest replacing id wins so every
+// client resolves identically.
+export function buildOracleReplacementMap(
+  tree: Record<string, Datasworn.RulesPackage>,
+  effectivePlayset: EffectivePlayset,
+): Record<string, string> {
+  const replacements: Record<string, string> = {};
+
+  const recordReplacement = (replacedId: string, replacingId: string) => {
+    const replacingPackageId = getPackageIdFromDataswornId(replacingId);
+    if (
+      !replacingPackageId ||
+      !effectivePlayset.isOracleIncluded(replacingPackageId, replacingId)
+    ) {
+      return;
+    }
+    const existing = replacements[replacedId];
+    if (existing === undefined || replacingId < existing) {
+      replacements[replacedId] = replacingId;
+    }
+  };
+
+  const getOracleMatches = (pattern: string) => {
+    try {
+      return IdParser.getMatches(pattern as Primary, tree);
+    } catch (e) {
+      console.error(`Failed to resolve datasworn id "${pattern}"`, e);
+      return new Map<string, unknown>();
+    }
+  };
+
+  const walkCollection = (collection: Datasworn.OracleCollection) => {
+    Object.values(collection.contents ?? {}).forEach((oracle) => {
+      oracle.replaces?.forEach((pattern: string) => {
+        getOracleMatches(pattern).forEach((match) => {
+          const matched = match as { _id?: string; type?: string };
+          if (matched.type === oracle.type && matched._id) {
+            recordReplacement(matched._id, oracle._id);
+          }
+        });
+      });
+    });
+
+    collection.replaces?.forEach((pattern) => {
+      getOracleMatches(pattern).forEach((match) => {
+        const matchedCollection = match as Datasworn.OracleCollection;
+        if (matchedCollection.type !== collection.type) return;
+        // A replacing collection replaces same-keyed oracles member-by-member
+        Object.entries(collection.contents ?? {}).forEach(([key, oracle]) => {
+          const replacedOracle = matchedCollection.contents?.[key];
+          if (replacedOracle) {
+            recordReplacement(replacedOracle._id, oracle._id);
+          }
+        });
+      });
+    });
+
+    if ("collections" in collection) {
+      Object.values(collection.collections ?? {}).forEach(walkCollection);
+    }
+  };
+
+  effectivePlayset.packageIds.forEach((packageId) => {
+    const rulesPackage = tree[packageId];
+    if (!rulesPackage) return;
+    Object.values(rulesPackage.oracles ?? {}).forEach(walkCollection);
+  });
+
+  return replacements;
+}
+
+export interface ResolvableOracleBinding {
+  oracleId: string;
+  resolvedOracleId: string;
+  exact?: boolean;
+}
+
+export function resolveOracleBinding(
+  binding: ResolvableOracleBinding,
+  replacementMap: Record<string, string>,
+): string {
+  if (binding.exact) {
+    return binding.oracleId;
+  }
+  return replacementMap[binding.oracleId] ?? binding.oracleId;
+}
+
+export interface BindingDivergence {
+  previousOracleId: string;
+  nextOracleId: string;
+}
+
+// Divergence is a diff against the binding's stored resolvedOracleId; a
+// non-null result must be surfaced (preview at the causing action, game-log
+// entries for everyone else) — never applied silently.
+export function getBindingDivergence(
+  binding: ResolvableOracleBinding,
+  replacementMap: Record<string, string>,
+): BindingDivergence | null {
+  const nextOracleId = resolveOracleBinding(binding, replacementMap);
+  if (nextOracleId === binding.resolvedOracleId) {
+    return null;
+  }
+  return {
+    previousOracleId: binding.resolvedOracleId,
+    nextOracleId,
+  };
+}

--- a/src/pages/pathConfig.ts
+++ b/src/pages/pathConfig.ts
@@ -8,6 +8,7 @@ export const pathConfig = {
   gameCharacterCreate: (gameId: string) => `/games/${gameId}/create`,
   gameJoin: (inviteKey: string) => `/join/${inviteKey}`,
   worldSelect: "/worlds",
+  worldCreate: "/worlds/create",
   world: (worldId: string) => `/worlds/${worldId}`,
   homebrewSelect: "/homebrew",
   homebrew: (homebrewId: string) => `/homebrew/${homebrewId}`,

--- a/src/pages/worlds/WorldCard.tsx
+++ b/src/pages/worlds/WorldCard.tsx
@@ -1,0 +1,58 @@
+import { Card, CardActionArea, Chip, Typography } from "@mui/material";
+
+import { LinkComponent } from "components/LinkComponent";
+
+import { pathConfig } from "pages/pathConfig";
+
+import { IWorld } from "services/worlds.service";
+
+import { getWorldSettingLabel } from "./hooks/useWorldSettings";
+
+export interface WorldCardProps {
+  worldId: string;
+  world: IWorld;
+}
+
+export function WorldCard(props: WorldCardProps) {
+  const { worldId, world } = props;
+
+  const settingLabel = getWorldSettingLabel(world.settingKey);
+
+  return (
+    <Card variant="outlined" sx={{ height: "100%" }}>
+      <CardActionArea
+        LinkComponent={LinkComponent}
+        href={pathConfig.world(worldId)}
+        sx={{
+          p: 2,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          height: "100%",
+          justifyContent: "flex-start",
+        }}
+      >
+        <Typography variant="h6" component="p" fontFamily="fontFamilyTitle">
+          {world.name}
+        </Typography>
+        {world.description && (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {world.description}
+          </Typography>
+        )}
+        {settingLabel && (
+          <Chip size="small" label={settingLabel} sx={{ mt: 1 }} />
+        )}
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/src/pages/worlds/WorldSelectPage.tsx
+++ b/src/pages/worlds/WorldSelectPage.tsx
@@ -1,27 +1,62 @@
 import { useTranslation } from "react-i18next";
 
+import { GradientButton } from "components/GradientButton";
 import { PageContent, PageHeader } from "components/Layout";
-import { EmptyState } from "components/Layout/EmptyState";
+import { GridLayout } from "components/Layout/GridLayout";
+
+import { pathConfig } from "pages/pathConfig";
 
 import {
   PageCategory,
   useSendPageViewEvent,
 } from "hooks/useSendPageViewEvents";
 
+import { useLoadUsersWorlds, useUsersWorlds } from "stores/users.worlds.store";
+
+import { WorldCard } from "./WorldCard";
+
 export default function WorldSelectPage() {
   const { t } = useTranslation();
   useSendPageViewEvent(PageCategory.WorldSelect);
 
+  useLoadUsersWorlds();
+  const worldState = useUsersWorlds();
+
   return (
     <>
-      <PageHeader label={t("worlds.title", "Worlds")} />
+      <PageHeader
+        label={t("worlds.list.header", "Your Worlds")}
+        actions={
+          <GradientButton href={pathConfig.worldCreate}>
+            {t("worlds.list.create", "Create World")}
+          </GradientButton>
+        }
+      />
       <PageContent>
-        <EmptyState
-          title={t("worlds.emptyState.title", "Coming Soon!")}
-          message={t(
-            "worlds.emptyState.description",
-            "Worlds are not yet available in the beta version.",
+        <GridLayout
+          items={Object.entries(worldState.worlds)}
+          renderItem={([worldId, world]) => (
+            <WorldCard worldId={worldId} world={world} />
           )}
+          loading={worldState.loading}
+          error={
+            worldState.error
+              ? t(
+                  "worlds.list.error-loading-worlds",
+                  "Failed to load your worlds. Please try again later.",
+                )
+              : undefined
+          }
+          emptyStateMessage={t(
+            "worlds.list.no-worlds-found",
+            "No worlds found",
+          )}
+          emptyStateAction={
+            <GradientButton href={pathConfig.worldCreate}>
+              {t("worlds.list.create", "Create World")}
+            </GradientButton>
+          }
+          minWidth={300}
         />
       </PageContent>
     </>

--- a/src/pages/worlds/create/CreateWorldPage.tsx
+++ b/src/pages/worlds/create/CreateWorldPage.tsx
@@ -1,0 +1,136 @@
+import {
+  Alert,
+  Card,
+  CardActionArea,
+  LinearProgress,
+  Radio,
+  TextField,
+  Typography,
+} from "@mui/material";
+import Box from "@mui/material/Box";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+
+import { GradientButton } from "components/GradientButton";
+import { PageContent, PageHeader } from "components/Layout";
+
+import { pathConfig } from "pages/pathConfig";
+
+import {
+  PageCategory,
+  useSendPageViewEvent,
+} from "hooks/useSendPageViewEvents";
+
+import { useWorldStore } from "stores/world.store";
+
+import { useWorldSettings } from "../hooks/useWorldSettings";
+
+export default function CreateWorldPage() {
+  const { t } = useTranslation();
+  useSendPageViewEvent(PageCategory.WorldCreate);
+
+  const navigate = useNavigate();
+  const createWorld = useWorldStore((store) => store.createWorld);
+
+  const { settings, loading: settingsLoading } = useWorldSettings();
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [settingKey, setSettingKey] = useState<string | undefined>();
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const handleCreate = () => {
+    if (!name.trim()) {
+      setError(
+        t("worlds.create.name-required", "Please enter a name for your world"),
+      );
+      return;
+    }
+    if (!settingKey) {
+      setError(t("worlds.create.setting-required", "Please choose a setting"));
+      return;
+    }
+    setError(undefined);
+    setCreating(true);
+    createWorld(name.trim(), description.trim() || undefined, settingKey)
+      .then((worldId) => {
+        navigate(pathConfig.world(worldId));
+      })
+      .catch(() => {
+        setCreating(false);
+        setError(
+          t(
+            "worlds.create.error-creating-world",
+            "Failed to create world. Please try again.",
+          ),
+        );
+      });
+  };
+
+  return (
+    <>
+      <PageHeader label={t("worlds.create.header", "Create a World")} />
+      <PageContent>
+        <Box
+          display="flex"
+          flexDirection="column"
+          gap={2}
+          maxWidth={600}
+          component="form"
+          onSubmit={(evt) => {
+            evt.preventDefault();
+            handleCreate();
+          }}
+        >
+          {error && <Alert severity="error">{error}</Alert>}
+          <TextField
+            label={t("worlds.create.name", "Name")}
+            value={name}
+            onChange={(evt) => setName(evt.target.value)}
+            required
+          />
+          <TextField
+            label={t("worlds.create.description", "Description")}
+            value={description}
+            onChange={(evt) => setDescription(evt.target.value)}
+            multiline
+            minRows={2}
+          />
+          <Typography variant="h6" component="p">
+            {t("worlds.create.setting-header", "Setting")}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {t(
+              "worlds.create.setting-description",
+              "The setting determines which truths your world starts from and where oracle fields look first.",
+            )}
+          </Typography>
+          {settingsLoading ? (
+            <LinearProgress />
+          ) : (
+            <Box display="flex" flexDirection="column" gap={1}>
+              {settings.map((setting) => (
+                <Card key={setting.key} variant="outlined">
+                  <CardActionArea
+                    onClick={() => setSettingKey(setting.key)}
+                    sx={{ p: 1, display: "flex", alignItems: "center" }}
+                  >
+                    <Radio checked={settingKey === setting.key} />
+                    <Typography>{setting.label}</Typography>
+                  </CardActionArea>
+                </Card>
+              ))}
+            </Box>
+          )}
+          <Box>
+            <GradientButton type="submit" disabled={creating}>
+              {t("worlds.create.submit", "Create World")}
+            </GradientButton>
+          </Box>
+        </Box>
+      </PageContent>
+    </>
+  );
+}

--- a/src/pages/worlds/hooks/useWorldSettings.ts
+++ b/src/pages/worlds/hooks/useWorldSettings.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+
+import { allDefaultPackages, includedExpansions } from "data/package.config";
+
+// A choosable world setting. Datasworn has no settings concept yet (see
+// iron-link-parity 02); until the fork-core `settings` field ships, every
+// truth-bearing package gets one synthesized setting. Keys are
+// package-qualified ("<packageId>/<settingKey>") so real per-package
+// settings dictionaries can slot in later without a data migration.
+export interface IWorldSetting {
+  key: string;
+  label: string;
+  // The packages a standalone world's playset starts from: the package
+  // itself, preceded by its parent ruleset when it is an expansion.
+  packageIds: string[];
+}
+
+export const SYNTHESIZED_SETTING_KEY = "default";
+
+function getParentRulesetId(packageId: string): string | undefined {
+  return Object.entries(includedExpansions).find(
+    ([, expansions]) => expansions[packageId] !== undefined,
+  )?.[0];
+}
+
+export function getWorldSettingPackageIds(settingKey: string): string[] {
+  const packageId = settingKey.split("/")[0];
+  const parentRulesetId = getParentRulesetId(packageId);
+  return parentRulesetId ? [parentRulesetId, packageId] : [packageId];
+}
+
+export function getWorldSettingLabel(
+  settingKey: string | null,
+): string | undefined {
+  if (!settingKey) return undefined;
+  const packageId = settingKey.split("/")[0];
+  return allDefaultPackages[packageId]?.name;
+}
+
+export function useWorldSettings(): {
+  settings: IWorldSetting[];
+  loading: boolean;
+} {
+  const [settings, setSettings] = useState<IWorldSetting[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    Promise.all(
+      Object.values(allDefaultPackages).map((config) =>
+        config
+          .load()
+          .then((rulesPackage) => ({ config, rulesPackage }))
+          .catch((error) => {
+            console.error(error);
+            return null;
+          }),
+      ),
+    ).then((results) => {
+      if (!isMounted) return;
+
+      const loadedSettings: IWorldSetting[] = [];
+      results.forEach((result) => {
+        if (!result) return;
+        const { config, rulesPackage } = result;
+        const truths =
+          "truths" in rulesPackage ? (rulesPackage.truths ?? {}) : {};
+        if (Object.keys(truths).length > 0) {
+          loadedSettings.push({
+            key: `${config.id}/${SYNTHESIZED_SETTING_KEY}`,
+            label: config.name,
+            packageIds: getWorldSettingPackageIds(config.id),
+          });
+        }
+      });
+      setSettings(loadedSettings);
+      setLoading(false);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { settings, loading };
+}

--- a/src/pages/worlds/worldPage/WorldMemberRow.tsx
+++ b/src/pages/worlds/worldPage/WorldMemberRow.tsx
@@ -1,0 +1,104 @@
+import DeleteIcon from "@mui/icons-material/DeleteOutline";
+import {
+  IconButton,
+  ListItem,
+  ListItemText,
+  MenuItem,
+  TextField,
+  Tooltip,
+} from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+import { useUID } from "stores/auth.store";
+import { useUserName } from "stores/users.store";
+import { useWorldStore } from "stores/world.store";
+
+import { IWorldPlayer, WorldPlayerRole } from "services/worldPlayers.service";
+
+export interface WorldMemberRowProps {
+  worldId: string;
+  player: IWorldPlayer;
+  isCurrentUserOwner: boolean;
+}
+
+export function WorldMemberRow(props: WorldMemberRowProps) {
+  const { worldId, player, isCurrentUserOwner } = props;
+  const { t } = useTranslation();
+
+  const uid = useUID();
+  const name = useUserName(player.userId);
+
+  const updateWorldPlayerRole = useWorldStore(
+    (store) => store.updateWorldPlayerRole,
+  );
+  const removeWorldPlayer = useWorldStore((store) => store.removeWorldPlayer);
+
+  const isSelf = player.userId === uid;
+  const isOwnerRow = player.role === WorldPlayerRole.Owner;
+
+  const roleLabels: Record<WorldPlayerRole, string> = {
+    [WorldPlayerRole.Owner]: t("worlds.roles.owner", "Owner"),
+    [WorldPlayerRole.Editor]: t("worlds.roles.editor", "Editor"),
+    [WorldPlayerRole.Viewer]: t("worlds.roles.viewer", "Viewer"),
+  };
+
+  // Owners can manage other members' roles; owner rows stay fixed so a world
+  // always keeps its owner (ownership transfer is not supported).
+  const canEditRole = isCurrentUserOwner && !isOwnerRow;
+  const canRemove =
+    (isCurrentUserOwner && !isOwnerRow) || (isSelf && !isOwnerRow);
+
+  return (
+    <ListItem
+      secondaryAction={
+        canRemove ? (
+          <Tooltip
+            title={
+              isSelf
+                ? t("worlds.members.leave", "Leave World")
+                : t("worlds.members.remove", "Remove Member")
+            }
+          >
+            <IconButton
+              edge="end"
+              onClick={() =>
+                removeWorldPlayer(worldId, player.userId).catch(() => {})
+              }
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Tooltip>
+        ) : undefined
+      }
+    >
+      <ListItemText primary={name} sx={{ mr: 2 }} />
+      {canEditRole ? (
+        <TextField
+          select
+          size="small"
+          value={player.role}
+          onChange={(evt) =>
+            updateWorldPlayerRole(
+              worldId,
+              player.userId,
+              evt.target.value as WorldPlayerRole,
+            ).catch(() => {})
+          }
+          sx={{ minWidth: 120 }}
+        >
+          <MenuItem value={WorldPlayerRole.Editor}>
+            {roleLabels[WorldPlayerRole.Editor]}
+          </MenuItem>
+          <MenuItem value={WorldPlayerRole.Viewer}>
+            {roleLabels[WorldPlayerRole.Viewer]}
+          </MenuItem>
+        </TextField>
+      ) : (
+        <ListItemText
+          secondary={roleLabels[player.role]}
+          sx={{ flexGrow: 0 }}
+        />
+      )}
+    </ListItem>
+  );
+}

--- a/src/pages/worlds/worldPage/WorldPage.tsx
+++ b/src/pages/worlds/worldPage/WorldPage.tsx
@@ -1,0 +1,215 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  Chip,
+  LinearProgress,
+  List,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useConfirm } from "material-ui-confirm";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router";
+
+import { PageContent, PageHeader } from "components/Layout";
+import { EmptyState } from "components/Layout/EmptyState";
+
+import { pathConfig } from "pages/pathConfig";
+
+import {
+  PageCategory,
+  useSendPageViewEvent,
+} from "hooks/useSendPageViewEvents";
+
+import { useListenToWorld, useWorldStore } from "stores/world.store";
+
+import { WorldPermission } from "repositories/shared.types";
+
+import { WorldPlayerRole } from "services/worldPlayers.service";
+
+import { getWorldSettingLabel } from "../hooks/useWorldSettings";
+import { WorldMemberRow } from "./WorldMemberRow";
+
+export default function WorldPage() {
+  const { t } = useTranslation();
+  useSendPageViewEvent(PageCategory.World);
+
+  const { worldId } = useParams<{ worldId: string }>();
+  useListenToWorld(worldId);
+
+  const navigate = useNavigate();
+  const confirm = useConfirm();
+
+  const world = useWorldStore((store) => store.world);
+  const worldPlayers = useWorldStore((store) => store.worldPlayers);
+  const worldPermission = useWorldStore((store) => store.worldPermission);
+  const loading = useWorldStore((store) => store.loading);
+  const error = useWorldStore((store) => store.error);
+  const worldDeleted = useWorldStore((store) => store.worldDeleted);
+
+  const updateWorldName = useWorldStore((store) => store.updateWorldName);
+  const updateWorldDescription = useWorldStore(
+    (store) => store.updateWorldDescription,
+  );
+  const deleteWorld = useWorldStore((store) => store.deleteWorld);
+
+  useEffect(() => {
+    if (worldDeleted) {
+      navigate(pathConfig.worldSelect);
+    }
+  }, [worldDeleted, navigate]);
+
+  const canEditWorld =
+    worldPermission === WorldPermission.Owner ||
+    worldPermission === WorldPermission.Editor;
+  const isOwner = worldPermission === WorldPermission.Owner;
+
+  const [editedName, setEditedName] = useState<string | undefined>();
+  const [editedDescription, setEditedDescription] = useState<
+    string | undefined
+  >();
+
+  if (loading) {
+    return <LinearProgress />;
+  }
+
+  if (error || !world || !worldId) {
+    return (
+      <PageContent>
+        <EmptyState
+          title={t("worlds.world.error-title", "World not found")}
+          message={t(
+            "worlds.world.error-description",
+            "This world may have been deleted, or you may not have access to it.",
+          )}
+        />
+      </PageContent>
+    );
+  }
+
+  const settingLabel = getWorldSettingLabel(world.settingKey);
+
+  const handleDelete = () => {
+    confirm({
+      title: t("worlds.world.delete-dialog-title", "Delete World"),
+      description: t(
+        "worlds.world.delete-dialog-description",
+        "Are you sure you want to delete this world? All of its entries will be deleted as well. This cannot be undone.",
+      ),
+      confirmationText: t("common.delete", "Delete"),
+    })
+      .then(({ confirmed }) => {
+        if (!confirmed) return;
+        deleteWorld(worldId).catch(() => {});
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <>
+      <PageHeader
+        label={world.name}
+        actions={
+          isOwner ? (
+            <Button color="error" variant="outlined" onClick={handleDelete}>
+              {t("worlds.world.delete", "Delete World")}
+            </Button>
+          ) : undefined
+        }
+      />
+      <PageContent>
+        <Box display="flex" flexDirection="column" gap={3} maxWidth={800}>
+          {settingLabel && (
+            <Box>
+              <Chip label={settingLabel} />
+            </Box>
+          )}
+
+          {canEditWorld ? (
+            <Card variant="outlined" sx={{ p: 2 }}>
+              <Typography variant="h6" component="p" mb={2}>
+                {t("worlds.world.details-header", "World Details")}
+              </Typography>
+              <Box display="flex" flexDirection="column" gap={2}>
+                <TextField
+                  label={t("worlds.world.name", "Name")}
+                  value={editedName ?? world.name}
+                  onChange={(evt) => setEditedName(evt.target.value)}
+                  onBlur={() => {
+                    const newName = editedName?.trim();
+                    if (newName && newName !== world.name) {
+                      updateWorldName(worldId, newName).catch(() => {});
+                    }
+                    setEditedName(undefined);
+                  }}
+                />
+                <TextField
+                  label={t("worlds.world.description", "Description")}
+                  value={editedDescription ?? world.description ?? ""}
+                  onChange={(evt) => setEditedDescription(evt.target.value)}
+                  onBlur={() => {
+                    if (
+                      editedDescription !== undefined &&
+                      editedDescription.trim() !== (world.description ?? "")
+                    ) {
+                      updateWorldDescription(
+                        worldId,
+                        editedDescription.trim() || null,
+                      ).catch(() => {});
+                    }
+                    setEditedDescription(undefined);
+                  }}
+                  multiline
+                  minRows={2}
+                />
+              </Box>
+            </Card>
+          ) : (
+            world.description && (
+              <Typography color="text.secondary">
+                {world.description}
+              </Typography>
+            )
+          )}
+
+          <Card variant="outlined" sx={{ p: 2 }}>
+            <Typography variant="h6" component="p">
+              {t("worlds.world.members-header", "Members")}
+            </Typography>
+            <List>
+              {Object.values(worldPlayers ?? {})
+                .sort((a, b) => {
+                  if (a.role === b.role)
+                    return a.userId.localeCompare(b.userId);
+                  return a.role === WorldPlayerRole.Owner ? -1 : 1;
+                })
+                .map((player) => (
+                  <WorldMemberRow
+                    key={player.userId}
+                    worldId={worldId}
+                    player={player}
+                    isCurrentUserOwner={isOwner}
+                  />
+                ))}
+            </List>
+            {worldPermission &&
+              worldPermission !== WorldPermission.None &&
+              !Object.values(worldPlayers ?? {}).some(
+                (p) => p.role !== WorldPlayerRole.Owner,
+              ) && (
+                <Alert severity="info">
+                  {t(
+                    "worlds.world.members-empty",
+                    "Players in games linked to this world get access automatically — no invites needed.",
+                  )}
+                </Alert>
+              )}
+          </Card>
+        </Box>
+      </PageContent>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Stacked on #192. Implements **W3** from the iron-link-parity plan:

- **World select page** replaces the "Coming Soon" stub: card grid of the user's worlds (explicit membership or via linked games — RLS does the filtering), setting chip per card.
- **Create-world page** (`/worlds/create`): name, description, and a setting picker. Settings are synthesized — one per truth-bearing package (Ironsworn, Starforged, Elegy, Sundered Isles; Delve/Starsmith correctly excluded) — until the fork-core `settings` field ships (02-datasworn-extensions). Keys are stored package-qualified (`<packageId>/default`) so real settings dictionaries slot in later without a data migration.
- **World overview page** (`/worlds/:worldId`): details editing for owners/editors, member list with role management (owner), self-removal, world deletion with confirm, live realtime updates.
- **Effective-playset resolver** (`src/lib/effectivePlayset.ts`, 17 unit tests): union over linked games' playsets, `replaces` gated on inclusion in ≥1 linked playset (absence ≠ veto, explicit exclusion respected), collection-level replaces member-by-member, deterministic tiebreak, `exact`-flag bindings, and divergence diff against stored `resolvedOracleId`. Pure module — W4's binding picker and W9's link/unlink previews consume it.

## Verification

- `tsc -b`, `eslint`, `vitest --run` (75/75), prettier all clean.
- **Verified end-to-end in the browser against a local Supabase** reset to these migrations: signed in, created "The Sundered Reach" through the UI (exercises the `create_world` RPC), landed on the world page, renamed it (realtime header update), confirmed the members list and owner-only controls, and hard-reloaded to confirm persistence. Also confirmed `supabase gen types --local` output matches the committed generated types byte-for-byte.

Running the real stack is also what surfaced the RLS recursion bug fixed in #192's follow-up commit (`world_players` policy self-reference → 42P17 on every worlds read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)