### PR TITLE
[codex] Fix adds race and reset after rolls

### DIFF
--- a/src/components/datasworn/Move/RollOptions/ActionRolls.tsx
+++ b/src/components/datasworn/Move/RollOptions/ActionRolls.tsx
@@ -3,7 +3,7 @@ import { Box, SxProps, Theme } from "@mui/material";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
-import { DebouncedConditionMeter } from "components/datasworn/ConditonMeter";
+import { ConditionMeter } from "components/datasworn/ConditonMeter";
 
 import { useGameCharactersStore } from "stores/gameCharacters.store";
 
@@ -72,7 +72,7 @@ export function ActionRolls(props: ActionRollsProps) {
         </React.Fragment>
       ))}
       {character && includeAdds && (
-        <DebouncedConditionMeter
+        <ConditionMeter
           label={t("character.character-sidebar.adds", "Adds")}
           min={-9}
           max={9}

--- a/src/pages/games/characterSheet/components/CharacterSection/Stats.tsx
+++ b/src/pages/games/characterSheet/components/CharacterSection/Stats.tsx
@@ -3,7 +3,7 @@ import { Box, Typography } from "@mui/material";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
-import { DebouncedConditionMeter } from "components/datasworn/ConditonMeter";
+import { ConditionMeter } from "components/datasworn/ConditonMeter";
 import { Stat } from "components/datasworn/Stat";
 
 import { useRollStatAndAddToLog } from "pages/games/hooks/useRollStatAndAddToLog.ts";
@@ -84,7 +84,7 @@ export function Stats() {
             }
           />
         ))}
-        <DebouncedConditionMeter
+        <ConditionMeter
           label={t("character.character-sidebar.adds", "Adds")}
           min={-9}
           max={9}

--- a/src/pages/games/hooks/useRollStatAndAddToLog.ts
+++ b/src/pages/games/hooks/useRollStatAndAddToLog.ts
@@ -7,6 +7,7 @@ import { getMove } from "hooks/datasworn/useMove";
 
 import { useAddRollSnackbar, useSetAnnouncement } from "stores/appState.store";
 import { useUID } from "stores/auth.store";
+import { useGameCharactersStore } from "stores/gameCharacters.store";
 import { useGameLogStore } from "stores/gameLog.store";
 
 import { createId } from "lib/id.lib";
@@ -43,14 +44,18 @@ export function useRollStatAndAddToLog() {
   const addRollSnackbar = useAddRollSnackbar();
 
   const addLog = useGameLogStore((store) => store.createLog);
+  const updateCharacterAdds = useGameCharactersStore(
+    (store) => store.updateCharacterAdds,
+  );
 
   const rollStat = useCallback(
     (config: StatRollConfig) => {
+      const resolvedCharacterId = config.characterId ?? characterId;
       const result = getStatRollResult(
         config,
         uid,
         gameId,
-        config.characterId ?? characterId,
+        resolvedCharacterId,
       );
 
       if (gameId) {
@@ -62,9 +67,22 @@ export function useRollStatAndAddToLog() {
         addRollSnackbar(result.id, result);
       }
 
+      if (resolvedCharacterId && result.adds !== 0) {
+        updateCharacterAdds(resolvedCharacterId, 0).catch(() => {});
+      }
+
       return result;
     },
-    [uid, characterId, gameId, t, announce, addRollSnackbar, addLog],
+    [
+      uid,
+      characterId,
+      gameId,
+      t,
+      announce,
+      addRollSnackbar,
+      addLog,
+      updateCharacterAdds,
+    ],
   );
 
   return rollStat;

--- a/src/stores/gameCharacters.store.ts
+++ b/src/stores/gameCharacters.store.ts
@@ -189,7 +189,24 @@ export const useGameCharactersStore = createWithEqualityFn<
       return CharacterService.updateMomentum(characterId, momentum);
     },
     updateCharacterAdds: (characterId, adds) => {
-      return CharacterService.updateAdds(characterId, adds);
+      const previousAdds = getState().characters[characterId]?.adds;
+
+      set((store) => {
+        if (store.characters[characterId]) {
+          store.characters[characterId].adds = adds;
+        }
+      });
+
+      return CharacterService.updateAdds(characterId, adds).catch((error) => {
+        if (previousAdds !== undefined) {
+          set((store) => {
+            if (store.characters[characterId]) {
+              store.characters[characterId].adds = previousAdds;
+            }
+          });
+        }
+        throw error;
+      });
     },
     updateCharacterImpactValue: (characterId, impactKey, checked) => {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

Fixes a race in the adds flow where quickly rolling after changing adds could use stale character data instead of the newly selected adds value.

## Root Cause

The Adds controls used `DebouncedConditionMeter`, so the visible meter value could change locally while the persisted character `adds` value still lagged behind. Roll actions read from character state, which meant a fast roll could miss the pending adds update.

## Changes

- Switched Adds controls on the character stats panel and move action rolls from debounced updates to immediate updates.
- Made `updateCharacterAdds` optimistic in the character store, with rollback if persistence fails.
- Reset nonzero adds to `0` after a stat roll consumes them.

## Validation

- `npx tsc --noEmit`
- `npx eslint . --quiet`