### PR TITLE
[codex] Centralize Datasworn replacement resolution

### DIFF
--- a/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,4 +1,3 @@
-import { Datasworn } from "@datasworn-community/core";
 import {
   Box,
   Link,
@@ -73,11 +72,7 @@ export function MarkdownRenderer(props: MarkdownRendererProps) {
                 .replace("{{table>", "");
               const oracle = getOracleRollable(id);
               if (oracle) {
-                return (
-                  <OracleTableRenderer
-                    oracle={oracle as Datasworn.OracleRollable}
-                  />
-                );
+                return <OracleTableRenderer oracle={oracle} />;
               }
             } else if (content.match(/^{{table:[^/]+\/truths\/[^}]+}}$/)) {
               return null;

--- a/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import { Datasworn, IdParser } from "@datasworn-community/core";
+import { Datasworn } from "@datasworn-community/core";
 import {
   Box,
   Link,
@@ -15,6 +15,10 @@ import remarkGfm from "remark-gfm";
 import { useOpenDataswornDialog } from "stores/appState.store";
 
 import { idMap } from "data/idMap";
+
+import { getDataswornItem } from "components/datasworn/DataswornDialog/useGetDataswornItem";
+
+import { getOracleRollable } from "hooks/datasworn/useOracleRollable";
 
 import { OracleTableRenderer } from "./OracleTableRenderer";
 
@@ -67,17 +71,13 @@ export function MarkdownRenderer(props: MarkdownRendererProps) {
                 .replace("{{table:", "")
                 .replace("}}", "")
                 .replace("{{table>", "");
-              let oracle: Datasworn.OracleRollable | undefined = undefined;
-              try {
-                const tmpOracle = IdParser.get(id) as Datasworn.OracleRollable;
-                if (tmpOracle.type === "oracle_rollable") {
-                  oracle = tmpOracle;
-                }
-              } catch {
-                // Empty - if oracle is undefined we will continue parsing
-              }
+              const oracle = getOracleRollable(id);
               if (oracle) {
-                return <OracleTableRenderer oracle={oracle} />;
+                return (
+                  <OracleTableRenderer
+                    oracle={oracle as Datasworn.OracleRollable}
+                  />
+                );
               }
             } else if (content.match(/^{{table:[^/]+\/truths\/[^}]+}}$/)) {
               return null;
@@ -202,13 +202,7 @@ export function MarkdownRenderer(props: MarkdownRendererProps) {
             // We have a datasworn id
             const id = idMap[strippedHref] ?? strippedHref;
 
-            let item: unknown;
-            try {
-              item = IdParser.get(id);
-            } catch {
-              // console.warn("Could not find in datasworn");
-              // Empty - if item is undefined we will continue parsing
-            }
+            const item = getDataswornItem(id);
 
             if (
               item &&

--- a/src/components/MarkdownRenderer/OracleTableRenderer.tsx
+++ b/src/components/MarkdownRenderer/OracleTableRenderer.tsx
@@ -6,7 +6,10 @@ import { Datasworn } from "@datasworn-community/core";
 // import { OracleTableSharedRolls } from "components/features/charactersAndCampaigns/LinkedDialog/LinkedDialogContent/OracleDialogContent/OracleTableSharedRolls";
 
 export interface OracleTableRendererProps {
-  oracle: Datasworn.OracleCollection | Datasworn.OracleRollable;
+  oracle:
+    | Datasworn.OracleCollection
+    | Datasworn.OracleRollable
+    | Datasworn.EmbeddedOracleRollable;
 }
 
 export function OracleTableRenderer(props: OracleTableRendererProps) {

--- a/src/components/datasworn/DataswornDialog/useGetDataswornItem.tsx
+++ b/src/components/datasworn/DataswornDialog/useGetDataswornItem.tsx
@@ -1,7 +1,15 @@
-import { Datasworn, IdParser } from "@datasworn-community/core";
-import { useEffect, useState } from "react";
+import { Datasworn } from "@datasworn-community/core";
 
-import { useDataswornTree } from "stores/dataswornTree.store";
+import { getAsset } from "hooks/datasworn/useAsset";
+import { getAssetCollection } from "hooks/datasworn/useAssetCollection";
+import { getMove } from "hooks/datasworn/useMove";
+import { getOracleCollection } from "hooks/datasworn/useOracleCollection";
+import { getOracleRollable } from "hooks/datasworn/useOracleRollable";
+
+import {
+  useDataswornTree,
+  useDataswornTreeStore,
+} from "stores/dataswornTree.store";
 
 type ReturnType =
   | {
@@ -18,7 +26,7 @@ type ReturnType =
     }
   | {
       type: "move";
-      move: Datasworn.Move;
+      move: Datasworn.Move | Datasworn.EmbeddedMove;
     }
   | {
       type: "asset_collection";
@@ -31,63 +39,62 @@ type ReturnType =
   | undefined;
 
 export function useGetDataswornItem(itemId: string): ReturnType {
-  const tree = useDataswornTree();
-
-  const [returnType, setReturnType] = useState<ReturnType>(
-    getDataswornItem(itemId, tree),
-  );
-
-  useEffect(() => {
-    setReturnType(getDataswornItem(itemId, tree));
-  }, [tree, itemId]);
-
-  return returnType;
+  useDataswornTree();
+  return getDataswornItem(itemId);
 }
 
-function getDataswornItem(
-  itemId: string,
-  tree: Record<string, Datasworn.RulesPackage>,
-): ReturnType {
-  try {
-    IdParser.tree = tree;
-    const item = IdParser.get(itemId);
-    if ((item as Datasworn.OracleCollection).type === "oracle_collection") {
-      return {
-        type: "oracle_collection",
-        oracleCollection: item as Datasworn.OracleCollection,
-      };
-    }
-    if ((item as Datasworn.OracleRollable).type === "oracle_rollable") {
-      return {
-        type: "oracle_rollable",
-        oracle: item as Datasworn.OracleRollable,
-      };
-    }
-    if ((item as Datasworn.MoveCategory).type === "move_category") {
-      return {
-        type: "move_category",
-        moveCategory: item as Datasworn.MoveCategory,
-      };
-    }
-    if ((item as Datasworn.Move).type === "move") {
-      return {
-        type: "move",
-        move: item as Datasworn.Move,
-      };
-    }
-    if ((item as Datasworn.AssetCollection).type === "asset_collection") {
-      return {
-        type: "asset_collection",
-        assetCollection: item as Datasworn.AssetCollection,
-      };
-    }
-    if ((item as Datasworn.Asset).type === "asset") {
-      return {
-        type: "asset",
-        asset: item as Datasworn.Asset,
-      };
-    }
-  } catch {
-    return undefined;
+export function getDataswornItem(itemId: string): ReturnType {
+  const oracle = getOracleRollable(itemId);
+  if (oracle) {
+    return {
+      type: "oracle_rollable",
+      oracle,
+    };
   }
+
+  const oracleCollection = getOracleCollection(itemId);
+  if (oracleCollection) {
+    return {
+      type: "oracle_collection",
+      oracleCollection,
+    };
+  }
+
+  const move = getMove(itemId);
+  if (move) {
+    return {
+      type: "move",
+      move,
+    };
+  }
+
+  const { moveCategoryAliases, moveCategoryMap } =
+    useDataswornTreeStore.getState().moves;
+  const moveCategory =
+    moveCategoryMap[moveCategoryAliases[itemId] ?? itemId] ??
+    moveCategoryMap[itemId];
+  if (moveCategory) {
+    return {
+      type: "move_category",
+      moveCategory,
+    };
+  }
+
+  const asset = getAsset(itemId);
+  if (asset) {
+    return {
+      type: "asset",
+      asset,
+    };
+  }
+
+  const assetCollection = getAssetCollection(itemId);
+  if (assetCollection) {
+    return {
+      type: "asset_collection",
+      assetCollection,
+    };
+  }
+
+  return undefined;
 }

--- a/src/components/datasworn/DataswornDialog/useGetDataswornItem.tsx
+++ b/src/components/datasworn/DataswornDialog/useGetDataswornItem.tsx
@@ -3,13 +3,11 @@ import { Datasworn } from "@datasworn-community/core";
 import { getAsset } from "hooks/datasworn/useAsset";
 import { getAssetCollection } from "hooks/datasworn/useAssetCollection";
 import { getMove } from "hooks/datasworn/useMove";
+import { getMoveCategory } from "hooks/datasworn/useMoveCategory";
 import { getOracleCollection } from "hooks/datasworn/useOracleCollection";
 import { getOracleRollable } from "hooks/datasworn/useOracleRollable";
 
-import {
-  useDataswornTree,
-  useDataswornTreeStore,
-} from "stores/dataswornTree.store";
+import { useDataswornTree } from "stores/dataswornTree.store";
 
 type ReturnType =
   | {
@@ -68,11 +66,7 @@ export function getDataswornItem(itemId: string): ReturnType {
     };
   }
 
-  const { moveCategoryAliases, moveCategoryMap } =
-    useDataswornTreeStore.getState().moves;
-  const moveCategory =
-    moveCategoryMap[moveCategoryAliases[itemId] ?? itemId] ??
-    moveCategoryMap[itemId];
+  const moveCategory = getMoveCategory(itemId);
   if (moveCategory) {
     return {
       type: "move_category",

--- a/src/components/datasworn/MoveTree/MoveCategoryListItem.tsx
+++ b/src/components/datasworn/MoveTree/MoveCategoryListItem.tsx
@@ -56,11 +56,6 @@ export function MoveCategoryListItem(props: MoveCategoryListItemProps) {
     return null;
   }
 
-  // This move category replaces another, we don't want to render it here
-  if (moveCategory.replaces && moveCategory._id === moveCategoryId) {
-    return null;
-  }
-
   const isExpandedOrForced = isExpanded || isSearchActive;
 
   return (

--- a/src/components/datasworn/Oracle/Oracle.tsx
+++ b/src/components/datasworn/Oracle/Oracle.tsx
@@ -28,11 +28,12 @@ export function Oracle(props: OracleProps) {
       ? cursedOracleAlternative
       : undefined,
   );
-  const [currentOracle, setCurrentOracle] = useState(oracleId);
+  const activeOracleId = oracle?._id ?? oracleId;
+  const [currentOracle, setCurrentOracle] = useState(activeOracleId);
 
   useEffect(() => {
-    setCurrentOracle(oracleId);
-  }, [oracleId]);
+    setCurrentOracle(activeOracleId);
+  }, [activeOracleId]);
 
   const { t } = useTranslation();
 

--- a/src/components/datasworn/OracleTree/OracleCollectionListItem.tsx
+++ b/src/components/datasworn/OracleTree/OracleCollectionListItem.tsx
@@ -58,14 +58,6 @@ export function OracleCollectionListItem(props: OracleCollectionListItemProps) {
 
   const isExpandedOrForced = isExpanded || isSearchActive;
 
-  // This oracle collection replaces another, we don't want to render it here
-  if (
-    oracleCollection.replaces &&
-    oracleCollection._id === oracleCollectionId
-  ) {
-    return null;
-  }
-
   if (
     oracleCollection.oracle_type === "table_shared_text" ||
     oracleCollection.oracle_type === "table_shared_text2" ||

--- a/src/hooks/datasworn/__tests__/resolvedDataswornItems.test.ts
+++ b/src/hooks/datasworn/__tests__/resolvedDataswornItems.test.ts
@@ -1,0 +1,66 @@
+import { Datasworn } from "@datasworn-community/core";
+import starforged from "@datasworn-community/starforged/json/starforged.json";
+import sunderedIsles from "@datasworn-community/sundered-isles/json/sundered_isles.json";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getDataswornItem } from "components/datasworn/DataswornDialog/useGetDataswornItem";
+
+import { useDataswornTreeStore } from "stores/dataswornTree.store";
+
+import { getMove } from "../useMove";
+import { getOracleCollection } from "../useOracleCollection";
+import { getOracleRollable } from "../useOracleRollable";
+
+const activeRules = {
+  [starforged._id]: starforged,
+  [sunderedIsles._id]: sunderedIsles,
+} as unknown as Record<string, Datasworn.RulesPackage>;
+
+describe("resolved Datasworn item accessors", () => {
+  beforeEach(() => {
+    useDataswornTreeStore.getState().setActiveRules(activeRules, {});
+  });
+
+  it("resolves replaced oracle rollable ids to active replacements", () => {
+    expect(
+      getOracleRollable(
+        "oracle_rollable:starforged/character/name/given_name",
+      )?._id,
+    ).toEqual("oracle_rollable:sundered_isles/character/name/given_name");
+  });
+
+  it("resolves replaced oracle collection ids to active replacements", () => {
+    expect(
+      getOracleCollection("oracle_collection:starforged/character/name")?._id,
+    ).toEqual("oracle_collection:sundered_isles/character/name");
+  });
+
+  it("resolves replaced move ids to active replacements", () => {
+    expect(getMove("move:starforged/recover/repair")?._id).toEqual(
+      "move:sundered_isles/recover/repair",
+    );
+  });
+
+  it("uses resolved items for Datasworn dialog lookups", () => {
+    const item = getDataswornItem("move:starforged/recover/repair");
+
+    expect(item?.type).toEqual("move");
+    if (item?.type === "move") {
+      expect(item.move._id).toEqual("move:sundered_isles/recover/repair");
+    }
+  });
+
+  it("does not resolve replacements from excluded collections", () => {
+    useDataswornTreeStore.getState().setActiveRules(activeRules, {
+      excludes: {
+        moveCategories: {
+          "move_category:sundered_isles/recover": true,
+        },
+      },
+    });
+
+    expect(getMove("move:starforged/recover/repair")?._id).toEqual(
+      "move:starforged/recover/repair",
+    );
+  });
+});

--- a/src/hooks/datasworn/useAsset.ts
+++ b/src/hooks/datasworn/useAsset.ts
@@ -3,9 +3,15 @@ import { Datasworn } from "@datasworn-community/core";
 import { useDataswornTreeStore } from "stores/dataswornTree.store";
 
 export function getAsset(assetId: string): Datasworn.Asset | undefined {
-  return useDataswornTreeStore.getState().assets.assetMap[assetId];
+  const { assetAliases, assetMap } = useDataswornTreeStore.getState().assets;
+  return assetMap[assetAliases[assetId] ?? assetId] ?? assetMap[assetId];
 }
 
 export function useAsset(assetId: string): Datasworn.Asset | undefined {
-  return useDataswornTreeStore((store) => store.assets.assetMap[assetId]);
+  return useDataswornTreeStore((store) => {
+    const resolvedAssetId = store.assets.assetAliases[assetId] ?? assetId;
+    return (
+      store.assets.assetMap[resolvedAssetId] ?? store.assets.assetMap[assetId]
+    );
+  });
 }

--- a/src/hooks/datasworn/useAssetCollection.ts
+++ b/src/hooks/datasworn/useAssetCollection.ts
@@ -2,10 +2,27 @@ import { Datasworn } from "@datasworn-community/core";
 
 import { useDataswornTreeStore } from "stores/dataswornTree.store";
 
+export function getAssetCollection(
+  assetCollectionId: string,
+): Datasworn.AssetCollection | undefined {
+  const { assetCollectionAliases, assetCollectionMap } =
+    useDataswornTreeStore.getState().assets;
+  return (
+    assetCollectionMap[assetCollectionAliases[assetCollectionId] ?? assetCollectionId] ??
+    assetCollectionMap[assetCollectionId]
+  );
+}
+
 export function useAssetCollection(
   assetCollectionId: string,
 ): Datasworn.AssetCollection | undefined {
-  return useDataswornTreeStore(
-    (store) => store.assets.assetCollectionMap[assetCollectionId],
-  );
+  return useDataswornTreeStore((store) => {
+    const resolvedAssetCollectionId =
+      store.assets.assetCollectionAliases[assetCollectionId] ??
+      assetCollectionId;
+    return (
+      store.assets.assetCollectionMap[resolvedAssetCollectionId] ??
+      store.assets.assetCollectionMap[assetCollectionId]
+    );
+  });
 }

--- a/src/hooks/datasworn/useMove.ts
+++ b/src/hooks/datasworn/useMove.ts
@@ -5,11 +5,15 @@ import { useDataswornTreeStore } from "stores/dataswornTree.store";
 export function getMove(
   moveId: string,
 ): Datasworn.Move | Datasworn.EmbeddedMove | undefined {
-  return useDataswornTreeStore.getState().moves.moveMap[moveId];
+  const { moveAliases, moveMap } = useDataswornTreeStore.getState().moves;
+  return moveMap[moveAliases[moveId] ?? moveId] ?? moveMap[moveId];
 }
 
 export function useMove(
   moveId: string,
 ): Datasworn.Move | Datasworn.EmbeddedMove | undefined {
-  return useDataswornTreeStore((store) => store.moves.moveMap[moveId]);
+  return useDataswornTreeStore((store) => {
+    const resolvedMoveId = store.moves.moveAliases[moveId] ?? moveId;
+    return store.moves.moveMap[resolvedMoveId] ?? store.moves.moveMap[moveId];
+  });
 }

--- a/src/hooks/datasworn/useMoveCategory.ts
+++ b/src/hooks/datasworn/useMoveCategory.ts
@@ -1,0 +1,27 @@
+import { Datasworn } from "@datasworn-community/core";
+
+import { useDataswornTreeStore } from "stores/dataswornTree.store";
+
+export function getMoveCategory(
+  moveCategoryId: string,
+): Datasworn.MoveCategory | undefined {
+  const { moveCategoryAliases, moveCategoryMap } =
+    useDataswornTreeStore.getState().moves;
+  return (
+    moveCategoryMap[moveCategoryAliases[moveCategoryId] ?? moveCategoryId] ??
+    moveCategoryMap[moveCategoryId]
+  );
+}
+
+export function useMoveCategory(
+  moveCategoryId: string,
+): Datasworn.MoveCategory | undefined {
+  return useDataswornTreeStore((store) => {
+    const resolvedMoveCategoryId =
+      store.moves.moveCategoryAliases[moveCategoryId] ?? moveCategoryId;
+    return (
+      store.moves.moveCategoryMap[resolvedMoveCategoryId] ??
+      store.moves.moveCategoryMap[moveCategoryId]
+    );
+  });
+}

--- a/src/hooks/datasworn/useOracleCollection.ts
+++ b/src/hooks/datasworn/useOracleCollection.ts
@@ -5,15 +5,25 @@ import { useDataswornTreeStore } from "stores/dataswornTree.store";
 export function getOracleCollection(
   oracleCollectionId: string,
 ): Datasworn.OracleCollection | undefined {
-  return useDataswornTreeStore.getState().oracles.oracleCollectionMap[
-    oracleCollectionId
-  ];
+  const { oracleCollectionAliases, oracleCollectionMap } =
+    useDataswornTreeStore.getState().oracles;
+  return (
+    oracleCollectionMap[
+      oracleCollectionAliases[oracleCollectionId] ?? oracleCollectionId
+    ] ?? oracleCollectionMap[oracleCollectionId]
+  );
 }
 
 export function useOracleCollection(
   oracleCollectionId: string,
 ): Datasworn.OracleCollection | undefined {
-  return useDataswornTreeStore(
-    (store) => store.oracles.oracleCollectionMap[oracleCollectionId],
-  );
+  return useDataswornTreeStore((store) => {
+    const resolvedOracleCollectionId =
+      store.oracles.oracleCollectionAliases[oracleCollectionId] ??
+      oracleCollectionId;
+    return (
+      store.oracles.oracleCollectionMap[resolvedOracleCollectionId] ??
+      store.oracles.oracleCollectionMap[oracleCollectionId]
+    );
+  });
 }

--- a/src/hooks/datasworn/useOracleRollable.ts
+++ b/src/hooks/datasworn/useOracleRollable.ts
@@ -5,17 +5,24 @@ import { useDataswornTreeStore } from "stores/dataswornTree.store";
 export function getOracleRollable(
   oracleRollableId: string,
 ): Datasworn.OracleRollable | Datasworn.EmbeddedOracleRollable | undefined {
-  return useDataswornTreeStore.getState().oracles.oracleRollableMap[
-    oracleRollableId
-  ];
+  const { oracleAliases, oracleRollableMap } =
+    useDataswornTreeStore.getState().oracles;
+  return (
+    oracleRollableMap[oracleAliases[oracleRollableId] ?? oracleRollableId] ??
+    oracleRollableMap[oracleRollableId]
+  );
 }
 
 export function useOracleRollable(
   oracleRollableId: string | undefined,
 ): Datasworn.OracleRollable | Datasworn.EmbeddedOracleRollable | undefined {
-  return useDataswornTreeStore((store) =>
-    oracleRollableId
-      ? store.oracles.oracleRollableMap[oracleRollableId]
-      : undefined,
-  );
+  return useDataswornTreeStore((store) => {
+    if (!oracleRollableId) return undefined;
+    const resolvedOracleRollableId =
+      store.oracles.oracleAliases[oracleRollableId] ?? oracleRollableId;
+    return (
+      store.oracles.oracleRollableMap[resolvedOracleRollableId] ??
+      store.oracles.oracleRollableMap[oracleRollableId]
+    );
+  });
 }

--- a/src/stores/dataswornTree.store.ts
+++ b/src/stores/dataswornTree.store.ts
@@ -155,7 +155,6 @@ export const useDataswornTreeStore = createWithEqualityFn<
           },
           "oracle_collection:*/*",
         );
-        console.log(moveMaps, oracleMaps);
         store.oracles = {
           oracleCollectionMap: oracleMaps.collectionMap,
           oracleRollableMap: oracleMaps.itemMap,

--- a/src/stores/dataswornTree.store.ts
+++ b/src/stores/dataswornTree.store.ts
@@ -38,6 +38,7 @@ export type OracleRollableMap = Record<
   string,
   Datasworn.OracleRollable | Datasworn.EmbeddedOracleRollable
 >;
+export type DataswornIdAliases = Record<string, string>;
 
 interface DataswornTreeStoreState {
   rulesError: string | null;
@@ -48,16 +49,22 @@ interface DataswornTreeStoreState {
     assetCollectionMap: AssetCollectionMap;
     assetMap: AssetMap;
     rootAssetCollections: RootCollections;
+    assetCollectionAliases: DataswornIdAliases;
+    assetAliases: DataswornIdAliases;
   };
   moves: {
     rootMoveCategories: RootMoveCategories;
     moveCategoryMap: MoveCategoryMap;
     moveMap: MoveMap;
+    moveCategoryAliases: DataswornIdAliases;
+    moveAliases: DataswornIdAliases;
   };
   oracles: {
     rootOracleCollections: RootOracleCollections;
     oracleCollectionMap: OracleCollectionMap;
     oracleRollableMap: OracleRollableMap;
+    oracleCollectionAliases: DataswornIdAliases;
+    oracleAliases: DataswornIdAliases;
   };
 
   statRules: Record<string, Datasworn.StatRule>;
@@ -89,16 +96,22 @@ export const useDataswornTreeStore = createWithEqualityFn<
       assetCollectionMap: {},
       assetMap: {},
       rootAssetCollections: {},
+      assetCollectionAliases: {},
+      assetAliases: {},
     },
     moves: {
       moveCategoryMap: {},
       moveMap: {},
       rootMoveCategories: {},
+      moveCategoryAliases: {},
+      moveAliases: {},
     },
     oracles: {
       oracleCollectionMap: {},
       oracleRollableMap: {},
       rootOracleCollections: {},
+      oracleCollectionAliases: {},
+      oracleAliases: {},
     },
 
     statRules: {},
@@ -131,6 +144,8 @@ export const useDataswornTreeStore = createWithEqualityFn<
           assetCollectionMap: assetMaps.collectionMap,
           assetMap: assetMaps.itemMap,
           rootAssetCollections: assetMaps.rootCollections,
+          assetCollectionAliases: assetMaps.collectionAliases,
+          assetAliases: assetMaps.itemAliases,
         };
 
         const moveMaps = parseCollectionsIntoMaps<Datasworn.MoveCategory>(
@@ -145,6 +160,8 @@ export const useDataswornTreeStore = createWithEqualityFn<
           moveCategoryMap: moveMaps.collectionMap,
           moveMap: moveMaps.itemMap,
           rootMoveCategories: moveMaps.rootCollections,
+          moveCategoryAliases: moveMaps.collectionAliases,
+          moveAliases: moveMaps.itemAliases,
         };
 
         const oracleMaps = parseCollectionsIntoMaps<Datasworn.OracleCollection>(
@@ -159,6 +176,8 @@ export const useDataswornTreeStore = createWithEqualityFn<
           oracleCollectionMap: oracleMaps.collectionMap,
           oracleRollableMap: oracleMaps.itemMap,
           rootOracleCollections: oracleMaps.rootCollections,
+          oracleCollectionAliases: oracleMaps.collectionAliases,
+          oracleAliases: oracleMaps.itemAliases,
         };
 
         Object.values(store.moves.moveMap).forEach((move) => {

--- a/src/stores/dataswornTreeHelpers/__tests__/parseCollectionsIntoMaps.test.ts
+++ b/src/stores/dataswornTreeHelpers/__tests__/parseCollectionsIntoMaps.test.ts
@@ -1,0 +1,107 @@
+import { Datasworn } from "@datasworn-community/core";
+import starforged from "@datasworn-community/starforged/json/starforged.json";
+import sunderedIsles from "@datasworn-community/sundered-isles/json/sundered_isles.json";
+import { describe, expect, it } from "vitest";
+
+import { parseCollectionsIntoMaps } from "../parseCollectionsIntoMaps";
+
+const activeRules = {
+  [starforged._id]: starforged,
+  [sunderedIsles._id]: sunderedIsles,
+} as unknown as Record<string, Datasworn.RulesPackage>;
+
+const emptyExclusions = {
+  collectionExclusions: {},
+  itemExclusions: {},
+};
+
+describe("parseCollectionsIntoMaps", () => {
+  it("renders replacing oracle collections in their natural location and aliases replaced ids", () => {
+    const maps = parseCollectionsIntoMaps<Datasworn.OracleCollection>(
+      activeRules,
+      emptyExclusions,
+      "oracle_collection:*/*",
+    );
+
+    expect(
+      maps.rootCollections.starforged.rootCollectionIds,
+    ).not.toContain("oracle_collection:starforged/character");
+    expect(maps.rootCollections.starforged.rootCollectionIds).toContain(
+      "oracle_collection:sundered_isles/character",
+    );
+
+    expect(
+      maps.collectionAliases["oracle_collection:starforged/character/name"],
+    ).toEqual("oracle_collection:sundered_isles/character/name");
+    expect(
+      maps.collectionMap["oracle_collection:starforged/character/name"]._id,
+    ).toEqual("oracle_collection:sundered_isles/character/name");
+
+    expect(
+      maps.collectionMap["oracle_collection:sundered_isles/character"]
+        .collections["oracle_collection:sundered_isles/character/name"]._id,
+    ).toEqual("oracle_collection:sundered_isles/character/name");
+  });
+
+  it("aliases replaced oracle rollables to their replacements", () => {
+    const maps = parseCollectionsIntoMaps<Datasworn.OracleCollection>(
+      activeRules,
+      emptyExclusions,
+      "oracle_collection:*/*",
+    );
+
+    expect(
+      maps.itemAliases[
+        "oracle_rollable:starforged/character/name/given_name"
+      ],
+    ).toEqual("oracle_rollable:sundered_isles/character/name/given_name");
+    expect(
+      maps.itemMap["oracle_rollable:starforged/character/name/given_name"]._id,
+    ).toEqual("oracle_rollable:sundered_isles/character/name/given_name");
+  });
+
+  it("merges enhancing move categories into their targets and removes replaced target moves", () => {
+    const maps = parseCollectionsIntoMaps<Datasworn.MoveCategory>(
+      activeRules,
+      emptyExclusions,
+      "move_category:*/*",
+    );
+
+    expect(maps.rootCollections.starforged.rootCollectionIds).toContain(
+      "move_category:starforged/recover",
+    );
+    expect(
+      maps.rootCollections.sundered_isles?.rootCollectionIds ?? [],
+    ).not.toContain("move_category:sundered_isles/recover");
+
+    const recoverMoves =
+      maps.collectionMap["move_category:starforged/recover"].contents;
+    expect(recoverMoves.repair._id).toEqual(
+      "move:sundered_isles/recover/repair",
+    );
+    expect(maps.itemMap["move:starforged/recover/repair"]._id).toEqual(
+      "move:sundered_isles/recover/repair",
+    );
+  });
+
+  it("does not let excluded collections replace or enhance active targets", () => {
+    const maps = parseCollectionsIntoMaps<Datasworn.MoveCategory>(
+      activeRules,
+      {
+        collectionExclusions: {
+          "move_category:sundered_isles/recover": true,
+        },
+        itemExclusions: {},
+      },
+      "move_category:*/*",
+    );
+
+    const recoverMoves =
+      maps.collectionMap["move_category:starforged/recover"].contents;
+    expect(recoverMoves.repair._id).toEqual("move:starforged/recover/repair");
+    expect(maps.itemAliases["move:starforged/recover/repair"]).toBeUndefined();
+    expect(maps.itemMap["move:starforged/recover/repair"]._id).toEqual(
+      "move:starforged/recover/repair",
+    );
+  });
+});

--- a/src/stores/dataswornTreeHelpers/__tests__/parseCollectionsIntoMaps.test.ts
+++ b/src/stores/dataswornTreeHelpers/__tests__/parseCollectionsIntoMaps.test.ts
@@ -37,9 +37,15 @@ describe("parseCollectionsIntoMaps", () => {
       maps.collectionMap["oracle_collection:starforged/character/name"]._id,
     ).toEqual("oracle_collection:sundered_isles/character/name");
 
+    const characterCollection =
+      maps.collectionMap["oracle_collection:sundered_isles/character"];
+    expect("collections" in characterCollection).toEqual(true);
+    if (!("collections" in characterCollection)) return;
+
     expect(
-      maps.collectionMap["oracle_collection:sundered_isles/character"]
-        .collections["oracle_collection:sundered_isles/character/name"]._id,
+      characterCollection.collections[
+        "oracle_collection:sundered_isles/character/name"
+      ]._id,
     ).toEqual("oracle_collection:sundered_isles/character/name");
   });
 

--- a/src/stores/dataswornTreeHelpers/parseCollectionsIntoMaps.ts
+++ b/src/stores/dataswornTreeHelpers/parseCollectionsIntoMaps.ts
@@ -19,6 +19,10 @@ type Items =
   | Datasworn.Move
   | Datasworn.OracleRollable
   | Datasworn.OracleColumnText;
+type ItemRecord = Record<string, Items>;
+type CollectionWithChildren<C extends Collections> = C & {
+  collections: Record<string, C>;
+};
 
 export type RootCollections = Record<
   string,
@@ -55,7 +59,7 @@ export function parseCollectionsIntoMaps<C extends Collections>(
   const allRootCollections: C[] = [];
 
   const collectionMap: Record<string, C> = {};
-  const itemMap: C["contents"] = {};
+  const itemMap: ItemRecord = {};
   const collectionAliases: Record<string, string> = {};
   const itemAliases: Record<string, string> = {};
   const replacedCollectionIds = new Set<string>();
@@ -126,7 +130,7 @@ export function parseCollectionsIntoMaps<C extends Collections>(
   Object.entries(itemAliases).forEach(([replacedId, replacementId]) => {
     const replacement = itemMap[replacementId];
     if (replacement) {
-      itemMap[replacedId as keyof C["contents"]] = replacement;
+      itemMap[replacedId] = replacement;
     }
   });
 
@@ -147,7 +151,7 @@ export function parseCollectionsIntoMaps<C extends Collections>(
   return {
     rootCollections,
     collectionMap,
-    itemMap,
+    itemMap: itemMap as C["contents"],
     collectionAliases,
     itemAliases,
   };
@@ -161,7 +165,7 @@ function parseCollection<C extends Collections>(
     itemExclusions: Record<string, boolean>;
   },
   collectionMap: Record<string, C>,
-  itemMap: C["contents"],
+  itemMap: ItemRecord,
   collectionAliases: Record<string, string>,
   itemAliases: Record<string, string>,
   replacedCollectionIds: Set<string>,
@@ -172,7 +176,7 @@ function parseCollection<C extends Collections>(
   const isExcluded = playsetExclusions.collectionExclusions[collection._id];
   if (isExcluded) return undefined;
 
-  const filteredContents: C["contents"] = {};
+  const filteredContents: ItemRecord = {};
   (Object.entries(collection.contents) as [string, Items][]).forEach(
     ([key, item]) => {
       const isItemExcluded = playsetExclusions.itemExclusions[item._id];
@@ -191,8 +195,8 @@ function parseCollection<C extends Collections>(
         });
       });
 
-      itemMap[item._id as keyof C["contents"]] = item;
-      filteredContents[key as keyof C["contents"]] = item;
+      itemMap[item._id] = item;
+      filteredContents[key] = item;
     },
   );
 
@@ -220,7 +224,7 @@ function parseCollection<C extends Collections>(
 
   const parsedCollection = {
     ...collection,
-    contents: filteredContents,
+    contents: filteredContents as C["contents"],
     ...("collections" in collection
       ? { collections: filteredCollections }
       : undefined),
@@ -271,24 +275,29 @@ function mergeCollectionEnhancement<C extends Collections>(
   });
 
   target.contents = {
-    ...filterRecordByItemId(target.contents, enhancedItemReplacementIds),
+    ...filterRecordByItemId(
+      target.contents as ItemRecord,
+      enhancedItemReplacementIds,
+    ),
     ...enhancer.contents,
-  };
+  } as C["contents"];
 
   if ("collections" in target && "collections" in enhancer) {
+    const targetWithChildren = target as CollectionWithChildren<C>;
+    const enhancerWithChildren = enhancer as CollectionWithChildren<C>;
     const enhancedCollectionReplacementIds = new Set<string>();
-    (Object.values(enhancer.collections) as C[]).forEach((collection) => {
+    Object.values(enhancerWithChildren.collections).forEach((collection) => {
       collection.replaces?.forEach((replacedId) => {
         enhancedCollectionReplacementIds.add(replacedId);
       });
     });
 
-    target.collections = {
+    targetWithChildren.collections = {
       ...filterRecordByItemId(
-        target.collections as Record<string, C>,
+        targetWithChildren.collections,
         enhancedCollectionReplacementIds,
       ),
-      ...(enhancer.collections as Record<string, C>),
+      ...enhancerWithChildren.collections,
     };
   }
 }
@@ -298,14 +307,18 @@ function removeHiddenEntries<C extends Collections>(
   replacedCollectionIds: Set<string>,
   replacedItemIds: Set<string>,
 ) {
-  collection.contents = filterRecordByItemId(collection.contents, replacedItemIds);
+  collection.contents = filterRecordByItemId(
+    collection.contents as ItemRecord,
+    replacedItemIds,
+  ) as C["contents"];
 
   if ("collections" in collection) {
-    collection.collections = filterRecordByItemId(
-      collection.collections as Record<string, C>,
+    const collectionWithChildren = collection as CollectionWithChildren<C>;
+    collectionWithChildren.collections = filterRecordByItemId(
+      collectionWithChildren.collections,
       replacedCollectionIds,
     );
-    (Object.values(collection.collections) as C[]).forEach((subCollection) => {
+    Object.values(collectionWithChildren.collections).forEach((subCollection) => {
       removeHiddenEntries(subCollection, replacedCollectionIds, replacedItemIds);
     });
   }

--- a/src/stores/dataswornTreeHelpers/parseCollectionsIntoMaps.ts
+++ b/src/stores/dataswornTreeHelpers/parseCollectionsIntoMaps.ts
@@ -28,6 +28,14 @@ export type RootCollections = Record<
   }
 >;
 
+export interface ParsedCollectionMaps<C extends Collections> {
+  rootCollections: RootCollections;
+  collectionMap: Record<string, C>;
+  itemMap: C["contents"];
+  collectionAliases: Record<string, string>;
+  itemAliases: Record<string, string>;
+}
+
 export function parseCollectionsIntoMaps<C extends Collections>(
   tree: Record<string, Datasworn.RulesPackage>,
   playsetExclusions: {
@@ -35,11 +43,7 @@ export function parseCollectionsIntoMaps<C extends Collections>(
     itemExclusions: Record<string, boolean>;
   },
   rootCollectionQueryRegex: string,
-): {
-  rootCollections: RootCollections;
-  collectionMap: Record<string, C>;
-  itemMap: C["contents"];
-} {
+): ParsedCollectionMaps<C> {
   // Get the root collections
   IdParser.tree = tree;
   const rootCollectionQueryResult = CollectionId.getMatches(
@@ -52,6 +56,13 @@ export function parseCollectionsIntoMaps<C extends Collections>(
 
   const collectionMap: Record<string, C> = {};
   const itemMap: C["contents"] = {};
+  const collectionAliases: Record<string, string> = {};
+  const itemAliases: Record<string, string> = {};
+  const replacedCollectionIds = new Set<string>();
+  const replacedItemIds = new Set<string>();
+  const enhancedCollectionIds = new Set<string>();
+  const enhancementTargets: Array<{ enhancerId: string; targetId: string }> =
+    [];
 
   rootCollectionQueryResult.forEach((rootCollection) => {
     const isCollectionExcluded =
@@ -75,15 +86,61 @@ export function parseCollectionsIntoMaps<C extends Collections>(
   });
 
   allRootCollections.forEach((collection) => {
-    if (collection) {
-      collectionMap[collection._id] = collection;
-      parseCollection(
-        collection,
-        tree,
-        playsetExclusions,
-        collectionMap,
-        itemMap,
-      );
+    const parsedCollection = parseCollection(
+      collection,
+      tree,
+      playsetExclusions,
+      collectionMap,
+      itemMap,
+      collectionAliases,
+      itemAliases,
+      replacedCollectionIds,
+      replacedItemIds,
+      enhancedCollectionIds,
+      enhancementTargets,
+    );
+    if (parsedCollection) {
+      collectionMap[parsedCollection._id] = parsedCollection;
+    }
+  });
+
+  enhancementTargets.forEach(({ enhancerId, targetId }) => {
+    const enhancer = collectionMap[enhancerId];
+    const target = collectionMap[targetId];
+    if (enhancer && target) {
+      mergeCollectionEnhancement(target, enhancer);
+    }
+  });
+
+  Object.values(collectionMap).forEach((collection) => {
+    removeHiddenEntries(collection, replacedCollectionIds, replacedItemIds);
+  });
+
+  Object.entries(collectionAliases).forEach(([replacedId, replacementId]) => {
+    const replacement = collectionMap[replacementId];
+    if (replacement) {
+      collectionMap[replacedId] = replacement;
+    }
+  });
+
+  Object.entries(itemAliases).forEach(([replacedId, replacementId]) => {
+    const replacement = itemMap[replacementId];
+    if (replacement) {
+      itemMap[replacedId as keyof C["contents"]] = replacement;
+    }
+  });
+
+  Object.values(rootCollections).forEach((rootCollection) => {
+    rootCollection.rootCollectionIds = rootCollection.rootCollectionIds.filter(
+      (rootCollectionId) =>
+        !replacedCollectionIds.has(rootCollectionId) &&
+        !enhancedCollectionIds.has(rootCollectionId),
+    );
+  });
+
+  Object.entries(rootCollections).forEach(([rulesetId, rootCollection]) => {
+    if (rootCollection.rootCollectionIds.length === 0) {
+      delete rootCollections[rulesetId];
     }
   });
 
@@ -91,6 +148,8 @@ export function parseCollectionsIntoMaps<C extends Collections>(
     rootCollections,
     collectionMap,
     itemMap,
+    collectionAliases,
+    itemAliases,
   };
 }
 
@@ -103,11 +162,15 @@ function parseCollection<C extends Collections>(
   },
   collectionMap: Record<string, C>,
   itemMap: C["contents"],
-) {
+  collectionAliases: Record<string, string>,
+  itemAliases: Record<string, string>,
+  replacedCollectionIds: Set<string>,
+  replacedItemIds: Set<string>,
+  enhancedCollectionIds: Set<string>,
+  enhancementTargets: Array<{ enhancerId: string; targetId: string }>,
+): C | undefined {
   const isExcluded = playsetExclusions.collectionExclusions[collection._id];
-  if (isExcluded) return;
-
-  collectionMap[collection._id] = collection;
+  if (isExcluded) return undefined;
 
   const filteredContents: C["contents"] = {};
   (Object.entries(collection.contents) as [string, Items][]).forEach(
@@ -122,74 +185,137 @@ function parseCollection<C extends Collections>(
         );
         replacedItems.forEach((value) => {
           if (value.type === item.type) {
-            itemMap[value._id] = value;
+            itemAliases[value._id] = item._id;
+            replacedItemIds.add(value._id);
           }
         });
       });
 
-      itemMap[item._id] = item;
-      filteredContents[key] = item;
+      itemMap[item._id as keyof C["contents"]] = item;
+      filteredContents[key as keyof C["contents"]] = item;
     },
   );
-  collectionMap[collection._id].contents = filteredContents;
 
   const filteredCollections: Record<string, C> = {};
   if ("collections" in collection) {
     (Object.values(collection.collections) as C[]).forEach((subCollection) => {
-      const isSubCollectionExcluded =
-        playsetExclusions.collectionExclusions[subCollection._id];
-      if (isSubCollectionExcluded) return;
-
-      filteredCollections[subCollection._id] = subCollection;
-      parseCollection(
+      const parsedSubCollection = parseCollection(
         subCollection,
         tree,
         playsetExclusions,
         collectionMap,
         itemMap,
+        collectionAliases,
+        itemAliases,
+        replacedCollectionIds,
+        replacedItemIds,
+        enhancedCollectionIds,
+        enhancementTargets,
       );
+      if (parsedSubCollection) {
+        filteredCollections[parsedSubCollection._id] = parsedSubCollection;
+      }
     });
   }
 
-  if (collection.replaces) {
-    collection.replaces.forEach((replacesKey) => {
-      const replacedItems = IdParser.getMatches(
-        replacesKey as StringId.Primary,
-        tree,
-      );
-      replacedItems.forEach((value) => {
-        if (value.type === collection.type) {
-          collectionMap[value._id] = collection;
-        }
+  const parsedCollection = {
+    ...collection,
+    contents: filteredContents,
+    ...("collections" in collection
+      ? { collections: filteredCollections }
+      : undefined),
+  } as C;
+  collectionMap[parsedCollection._id] = parsedCollection;
+
+  collection.replaces?.forEach((replacesKey) => {
+    const replacedItems = IdParser.getMatches(
+      replacesKey as StringId.Primary,
+      tree,
+    );
+    replacedItems.forEach((value) => {
+      if (value.type === collection.type) {
+        collectionAliases[value._id] = collection._id;
+        replacedCollectionIds.add(value._id);
+      }
+    });
+  });
+
+  collection.enhances?.forEach((enhancesKey) => {
+    const enhancedItems = IdParser.getMatches(
+      enhancesKey as StringId.Primary,
+      tree,
+    );
+    enhancedItems.forEach((value) => {
+      if (value.type === collection.type) {
+        enhancedCollectionIds.add(collection._id);
+        enhancementTargets.push({
+          enhancerId: collection._id,
+          targetId: value._id,
+        });
+      }
+    });
+  });
+
+  return parsedCollection;
+}
+
+function mergeCollectionEnhancement<C extends Collections>(
+  target: C,
+  enhancer: C,
+) {
+  const enhancedItemReplacementIds = new Set<string>();
+  (Object.values(enhancer.contents) as Items[]).forEach((item) => {
+    item.replaces?.forEach((replacedId) => {
+      enhancedItemReplacementIds.add(replacedId);
+    });
+  });
+
+  target.contents = {
+    ...filterRecordByItemId(target.contents, enhancedItemReplacementIds),
+    ...enhancer.contents,
+  };
+
+  if ("collections" in target && "collections" in enhancer) {
+    const enhancedCollectionReplacementIds = new Set<string>();
+    (Object.values(enhancer.collections) as C[]).forEach((collection) => {
+      collection.replaces?.forEach((replacedId) => {
+        enhancedCollectionReplacementIds.add(replacedId);
       });
     });
-  } else if (collection.enhances) {
-    delete collectionMap[collection._id];
-    collection.enhances.forEach((enhancesKey) => {
-      const enhancedItems = IdParser.getMatches(
-        enhancesKey as StringId.Primary,
-        tree,
-      );
-      enhancedItems.forEach((value) => {
-        if (value.type === collection.type) {
-          if (collectionMap[value._id]) {
-            collectionMap[value._id].contents = {
-              ...collectionMap[value._id].contents,
-              ...filteredContents,
-              //  type will be correct based on the value.type === collection.type above
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            } as any;
-            if ("collections" in collection) {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (collectionMap[value._id] as any).collections = {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                ...(collectionMap[value._id] as any).collections,
-                ...filteredCollections,
-              };
-            }
-          }
-        }
-      });
+
+    target.collections = {
+      ...filterRecordByItemId(
+        target.collections as Record<string, C>,
+        enhancedCollectionReplacementIds,
+      ),
+      ...(enhancer.collections as Record<string, C>),
+    };
+  }
+}
+
+function removeHiddenEntries<C extends Collections>(
+  collection: C,
+  replacedCollectionIds: Set<string>,
+  replacedItemIds: Set<string>,
+) {
+  collection.contents = filterRecordByItemId(collection.contents, replacedItemIds);
+
+  if ("collections" in collection) {
+    collection.collections = filterRecordByItemId(
+      collection.collections as Record<string, C>,
+      replacedCollectionIds,
+    );
+    (Object.values(collection.collections) as C[]).forEach((subCollection) => {
+      removeHiddenEntries(subCollection, replacedCollectionIds, replacedItemIds);
     });
   }
+}
+
+function filterRecordByItemId<T extends { _id: string }>(
+  record: Record<string, T>,
+  removedIds: Set<string>,
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => !removedIds.has(value._id)),
+  );
 }


### PR DESCRIPTION
## Summary

Centralizes Datasworn replacement and enhancement handling in the collection parsing layer so sidebars, renderers, rolls, markdown links, and dialogs all resolve active content consistently.

## What changed

- Reworked `parseCollectionsIntoMaps` to own replacement/enhancement policy.
- Keeps explicit alias maps for replaced collection and item ids.
- Removes replaced targets from renderable collection trees while preserving old ids for lookup compatibility.
- Merges enhancing collections into their targets, including replacement-aware item merging.
- Makes playset exclusions prevent excluded collections from replacing or enhancing active targets.
- Updates Datasworn hooks, dialog lookup, markdown datasworn links/table embeds, and oracle rendering to use resolved active ids.
- Adds focused tests around Sundered Isles collection replacement, item replacement, move enhancement, playset exclusions, and renderer-facing getters.

## Root Cause

Replacement behavior was split between parser maps and UI render guards. Nested replacements like Sundered Isles `character/name` could be hidden when rendered under their own id, while raw `IdParser` consumers bypassed the active replacement maps entirely.

## Validation

- `npx tsc --noEmit`
- `npx eslint . --quiet`
- `VITE_SUPABASE_URL=http://127.0.0.1:54321 VITE_SUPABASE_ANON_KEY=test-anon-key npx vitest --run`

Note: full Vitest still prints existing jsdom warnings for audio loading and React `act`, but all tests pass.
