### PR TITLE
[codex] Add Lodestar rules package selector support

### DIFF
--- a/src/components/datasworn/RulesPackageSelector/ExpansionCheckboxListRenderer.tsx
+++ b/src/components/datasworn/RulesPackageSelector/ExpansionCheckboxListRenderer.tsx
@@ -12,7 +12,11 @@ import {
 import { Dispatch, SetStateAction, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { IExpansionConfig } from "data/package.config";
+import {
+  IExpansionConfig,
+  getExpansionDependencies,
+  getExpansionDependents,
+} from "data/package.config";
 import { defaultPlaysets } from "data/playset.config";
 
 import { PlaysetConfig } from "repositories/game.repository";
@@ -67,7 +71,17 @@ export function ExpansionCheckboxListRenderer(
         <Box key={expansionKey}>
           <FormControlLabel
             key={expansionKey}
-            label={expansion.name}
+            label={
+              <Box component="span" display="inline-flex" alignItems="center">
+                {expansion.name}
+                <ExpansionDependencyTooltip
+                  rulesetKey={rulesetKey}
+                  expansionKey={expansionKey}
+                  expansionName={expansion.name}
+                  expansions={expansions}
+                />
+              </Box>
+            }
             control={
               <Checkbox
                 checked={
@@ -121,5 +135,50 @@ export function ExpansionCheckboxListRenderer(
         </Box>
       ))}
     </>
+  );
+}
+
+interface ExpansionDependencyTooltipProps {
+  rulesetKey: string;
+  expansionKey: string;
+  expansionName: string;
+  expansions: Record<string, IExpansionConfig>;
+}
+
+function ExpansionDependencyTooltip(props: ExpansionDependencyTooltipProps) {
+  const { rulesetKey, expansionKey, expansionName, expansions } = props;
+  const { t } = useTranslation();
+
+  const dependencyNames = getExpansionDependencies(rulesetKey, expansionKey)
+    .map((dependencyKey) => expansions[dependencyKey]?.name)
+    .filter(Boolean);
+  const dependentNames = getExpansionDependents(rulesetKey, expansionKey)
+    .map((dependentKey) => expansions[dependentKey]?.name)
+    .filter(Boolean);
+
+  const dependencyList = dependencyNames.join(", ");
+  const dependentList = dependentNames.join(", ");
+
+  const tooltip =
+    dependencyList.length > 0
+      ? t(
+          "ruleset-selector.expansion-enables-dependencies",
+          "{{expansion}} uses content from {{dependencies}}, so enabling it also enables {{dependencies}}.",
+          { expansion: expansionName, dependencies: dependencyList },
+        )
+      : dependentList.length > 0
+        ? t(
+            "ruleset-selector.expansion-disables-dependents",
+            "{{dependents}} depends on {{expansion}}, so turning {{expansion}} off also turns {{dependents}} off.",
+            { dependents: dependentList, expansion: expansionName },
+          )
+        : null;
+
+  if (!tooltip) return null;
+
+  return (
+    <Tooltip title={tooltip}>
+      <InfoIcon color="info" fontSize="small" sx={{ ml: 0.5 }} />
+    </Tooltip>
   );
 }

--- a/src/components/datasworn/RulesPackageSelector/ExpansionCheckboxListRenderer.tsx
+++ b/src/components/datasworn/RulesPackageSelector/ExpansionCheckboxListRenderer.tsx
@@ -12,15 +12,12 @@ import {
 import { Dispatch, SetStateAction, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import {
-  IExpansionConfig,
-  getExpansionDependencies,
-  getExpansionDependents,
-} from "data/package.config";
+import { IExpansionConfig } from "data/package.config";
 import { defaultPlaysets } from "data/playset.config";
 
 import { PlaysetConfig } from "repositories/game.repository";
 
+import { ExpansionDependencyTooltip } from "./ExpansionDependencyTooltip";
 import { LicenseInfo } from "./LicenseInfo";
 
 export interface ExpansionCheckboxListRendererProps {
@@ -135,50 +132,5 @@ export function ExpansionCheckboxListRenderer(
         </Box>
       ))}
     </>
-  );
-}
-
-interface ExpansionDependencyTooltipProps {
-  rulesetKey: string;
-  expansionKey: string;
-  expansionName: string;
-  expansions: Record<string, IExpansionConfig>;
-}
-
-function ExpansionDependencyTooltip(props: ExpansionDependencyTooltipProps) {
-  const { rulesetKey, expansionKey, expansionName, expansions } = props;
-  const { t } = useTranslation();
-
-  const dependencyNames = getExpansionDependencies(rulesetKey, expansionKey)
-    .map((dependencyKey) => expansions[dependencyKey]?.name)
-    .filter(Boolean);
-  const dependentNames = getExpansionDependents(rulesetKey, expansionKey)
-    .map((dependentKey) => expansions[dependentKey]?.name)
-    .filter(Boolean);
-
-  const dependencyList = dependencyNames.join(", ");
-  const dependentList = dependentNames.join(", ");
-
-  const tooltip =
-    dependencyList.length > 0
-      ? t(
-          "ruleset-selector.expansion-enables-dependencies",
-          "{{expansion}} uses content from {{dependencies}}, so enabling it also enables {{dependencies}}.",
-          { expansion: expansionName, dependencies: dependencyList },
-        )
-      : dependentList.length > 0
-        ? t(
-            "ruleset-selector.expansion-disables-dependents",
-            "{{dependents}} depends on {{expansion}}, so turning {{expansion}} off also turns {{dependents}} off.",
-            { dependents: dependentList, expansion: expansionName },
-          )
-        : null;
-
-  if (!tooltip) return null;
-
-  return (
-    <Tooltip title={tooltip}>
-      <InfoIcon color="info" fontSize="small" sx={{ ml: 0.5 }} />
-    </Tooltip>
   );
 }

--- a/src/components/datasworn/RulesPackageSelector/ExpansionDependencyTooltip.tsx
+++ b/src/components/datasworn/RulesPackageSelector/ExpansionDependencyTooltip.tsx
@@ -1,0 +1,56 @@
+import InfoIcon from "@mui/icons-material/Info";
+import { Tooltip } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+import {
+  IExpansionConfig,
+  getExpansionDependencies,
+  getExpansionDependents,
+} from "data/package.config";
+
+interface ExpansionDependencyTooltipProps {
+  rulesetKey: string;
+  expansionKey: string;
+  expansionName: string;
+  expansions: Record<string, IExpansionConfig>;
+}
+
+export function ExpansionDependencyTooltip(
+  props: ExpansionDependencyTooltipProps,
+) {
+  const { rulesetKey, expansionKey, expansionName, expansions } = props;
+  const { t } = useTranslation();
+
+  const dependencyNames = getExpansionDependencies(rulesetKey, expansionKey)
+    .map((dependencyKey) => expansions[dependencyKey]?.name)
+    .filter(Boolean);
+  const dependentNames = getExpansionDependents(rulesetKey, expansionKey)
+    .map((dependentKey) => expansions[dependentKey]?.name)
+    .filter(Boolean);
+
+  const dependencyList = dependencyNames.join(", ");
+  const dependentList = dependentNames.join(", ");
+
+  const tooltip =
+    dependencyList.length > 0
+      ? t(
+          "ruleset-selector.expansion-enables-dependencies",
+          "{{expansion}} uses content from {{dependencies}}, so enabling it also enables {{dependencies}}.",
+          { expansion: expansionName, dependencies: dependencyList },
+        )
+      : dependentList.length > 0
+        ? t(
+            "ruleset-selector.expansion-disables-dependents",
+            "{{dependents}} depends on {{expansion}}, so turning {{expansion}} off also turns {{dependents}} off.",
+            { dependents: dependentList, expansion: expansionName },
+          )
+        : null;
+
+  if (!tooltip) return null;
+
+  return (
+    <Tooltip title={tooltip}>
+      <InfoIcon color="info" fontSize="small" sx={{ ml: 0.5 }} />
+    </Tooltip>
+  );
+}

--- a/src/components/datasworn/RulesPackageSelector/RulesPackageSelector.tsx
+++ b/src/components/datasworn/RulesPackageSelector/RulesPackageSelector.tsx
@@ -1,10 +1,18 @@
 import { Box, Button, SxProps, Theme } from "@mui/material";
-import { Dispatch, SetStateAction, useMemo, useState } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import {
   IExpansionConfig,
   IRulesetConfig,
+  getExpansionDependencies,
+  getExpansionDependents,
   includedExpansions,
   includedRulesets,
 } from "data/package.config";
@@ -70,6 +78,27 @@ export function RulesPackageSelector(props: RulesPackageSelectorProps) {
     (val) => val,
   );
 
+  const handleExpansionChange = useCallback(
+    (rulesetKey: string, expansionKey: string, isActive: boolean) => {
+      if (isActive) {
+        getExpansionDependencies(rulesetKey, expansionKey).forEach(
+          (dependencyKey) => {
+            onExpansionChange(rulesetKey, dependencyKey, true);
+          },
+        );
+      } else {
+        getExpansionDependents(rulesetKey, expansionKey).forEach(
+          (dependentKey) => {
+            onExpansionChange(rulesetKey, dependentKey, false);
+          },
+        );
+      }
+
+      onExpansionChange(rulesetKey, expansionKey, isActive);
+    },
+    [onExpansionChange],
+  );
+
   return (
     <Box sx={sx}>
       <RulesetCheckboxListRenderer
@@ -79,7 +108,7 @@ export function RulesPackageSelector(props: RulesPackageSelectorProps) {
         onRulesetChange={onRulesetChange}
         expansions={expansions}
         activeExpansionConfig={activeExpansionConfig}
-        onExpansionChange={onExpansionChange}
+        onExpansionChange={handleExpansionChange}
         activePlaysetConfig={activePlaysetConfig}
         onPlaysetChange={onPlaysetChange}
       />
@@ -90,7 +119,7 @@ export function RulesPackageSelector(props: RulesPackageSelectorProps) {
         onRulesetChange={onRulesetChange}
         expansions={expansions}
         activeExpansionConfig={activeExpansionConfig}
-        onExpansionChange={onExpansionChange}
+        onExpansionChange={handleExpansionChange}
         activePlaysetConfig={activePlaysetConfig}
         onPlaysetChange={onPlaysetChange}
       />

--- a/src/data/package.config.ts
+++ b/src/data/package.config.ts
@@ -52,6 +52,22 @@ export const ironswornDelveConfig: IExpansionConfig = {
   isHomebrew: false,
 };
 
+export const ironswornLodestarConfig: IExpansionConfig = {
+  id: "lodestar",
+  name: "Lodestar",
+  type: "expansion",
+  load: async () => {
+    const ironswornLodestarJSON = await import(
+      "@datasworn-community/ironsworn-classic-lodestar/json/lodestar.json"
+    );
+    return {
+      ...ironswornLodestarJSON,
+      title: "Lodestar",
+    } as unknown as Datasworn.Expansion;
+  },
+  isHomebrew: false,
+};
+
 export const starforgedRulesetConfig: IRulesetConfig = {
   id: "starforged",
   name: "Starforged",
@@ -137,6 +153,7 @@ export const includedExpansions: Record<
 > = {
   [ironswornRulesetConfig.id]: {
     [ironswornDelveConfig.id]: ironswornDelveConfig,
+    [ironswornLodestarConfig.id]: ironswornLodestarConfig,
   },
   [starforgedRulesetConfig.id]: {
     [sunderedIslesConfig.id]: sunderedIslesConfig,
@@ -144,9 +161,61 @@ export const includedExpansions: Record<
   },
 };
 
+export const expansionDependencies: Record<string, Record<string, string[]>> = {
+  [ironswornRulesetConfig.id]: {
+    [ironswornLodestarConfig.id]: [ironswornDelveConfig.id],
+  },
+};
+
+export function getExpansionDependencies(
+  rulesetId: string,
+  expansionId: string,
+): string[] {
+  return expansionDependencies[rulesetId]?.[expansionId] ?? [];
+}
+
+export function getExpansionDependents(
+  rulesetId: string,
+  expansionId: string,
+): string[] {
+  return Object.entries(expansionDependencies[rulesetId] ?? {})
+    .filter(([, dependencyIds]) => dependencyIds.includes(expansionId))
+    .map(([dependentId]) => dependentId);
+}
+
+export function enforceExpansionDependencies<
+  T extends Record<string, Record<string, boolean>>,
+>(expansions: T): T {
+  const next = { ...expansions } as T;
+
+  Object.entries(expansionDependencies).forEach(
+    ([rulesetId, dependentRules]) => {
+      const rulesetExpansions = next[rulesetId];
+      if (!rulesetExpansions) return;
+
+      Object.entries(dependentRules).forEach(([dependentId, dependencyIds]) => {
+        const isDependentActive = rulesetExpansions[dependentId] ?? false;
+        const areDependenciesActive = dependencyIds.every(
+          (dependencyId) => rulesetExpansions[dependencyId] ?? false,
+        );
+
+        if (isDependentActive && !areDependenciesActive) {
+          next[rulesetId] = {
+            ...rulesetExpansions,
+            [dependentId]: false,
+          };
+        }
+      });
+    },
+  );
+
+  return next;
+}
+
 export const allDefaultPackages: Record<string, IPackageConfig> = {
   ...includedRulesets,
   [ironswornDelveConfig.id]: ironswornDelveConfig,
+  [ironswornLodestarConfig.id]: ironswornLodestarConfig,
   [sunderedIslesConfig.id]: sunderedIslesConfig,
   [starsmithConfig.id]: starsmithConfig,
 };

--- a/src/pages/games/create/hooks/useSyncActiveRulesPackages.ts
+++ b/src/pages/games/create/hooks/useSyncActiveRulesPackages.ts
@@ -3,7 +3,11 @@ import { useEffect, useState } from "react";
 
 import { useDataswornTreeStore } from "stores/dataswornTree.store";
 
-import { allDefaultPackages, includedExpansions } from "data/package.config";
+import {
+  allDefaultPackages,
+  enforceExpansionDependencies,
+  includedExpansions,
+} from "data/package.config";
 
 import {
   ExpansionConfig,
@@ -26,11 +30,12 @@ export function useSyncActiveRulesPackages(
   useEffect(() => {
     setTreeError(null);
     const packagePromises: Promise<Datasworn.RulesPackage>[] = [];
+    const activeExpansions = enforceExpansionDependencies(expansions ?? {});
 
     Object.entries(rulesets ?? {}).forEach(([id, isActive]) => {
       if (isActive) {
         packagePromises.push(allDefaultPackages[id].load());
-        Object.entries(expansions?.[id] ?? {}).forEach(
+        Object.entries(activeExpansions[id] ?? {}).forEach(
           ([expansionId, isExpansionActive]) => {
             if (isExpansionActive && includedExpansions[id]?.[expansionId]) {
               packagePromises.push(allDefaultPackages[expansionId].load());

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -1,3 +1,5 @@
+import { enforceExpansionDependencies } from "data/package.config";
+
 import { RepositoryError } from "repositories/errors/RepositoryErrors";
 import {
   ExpansionConfig,
@@ -51,11 +53,13 @@ export class GameService {
     expansions: Record<string, Record<string, boolean>>,
     playset: PlaysetConfig,
   ): Promise<string> {
+    const enforcedExpansions = enforceExpansionDependencies(expansions);
+
     const gameId = await GameRepository.createGame(
       gameName,
       gameType,
       rulesets,
-      expansions,
+      enforcedExpansions,
       playset,
     );
 
@@ -219,7 +223,13 @@ export class GameService {
     expansions: ExpansionConfig,
     playset: PlaysetConfig,
   ): Promise<void> {
-    await GameRepository.updateGame(gameId, { rulesets, expansions, playset });
+    const enforcedExpansions = enforceExpansionDependencies(expansions);
+
+    await GameRepository.updateGame(gameId, {
+      rulesets,
+      expansions: enforcedExpansions,
+      playset,
+    });
   }
 
   public static async updateColorScheme(
@@ -267,7 +277,9 @@ export class GameService {
       gameType,
       colorScheme,
       rulesets: gameDTO.rulesets as Record<string, boolean>,
-      expansions: gameDTO.expansions as Record<string, Record<string, boolean>>,
+      expansions: enforceExpansionDependencies(
+        gameDTO.expansions as Record<string, Record<string, boolean>>,
+      ),
       playset: gameDTO.playset as PlaysetConfig,
     };
   }


### PR DESCRIPTION
## Summary

Adds the installed `@datasworn-community/ironsworn-classic-lodestar` package to the rules package loading mechanism and selector.

## What changed

- Registers Lodestar as an official Ironsworn expansion and loads `json/lodestar.json`.
- Adds dependency metadata so Lodestar depends on Delve.
- Cascades selector toggles so enabling Lodestar enables Delve, and disabling Delve disables Lodestar.
- Normalizes expansion config during game create/update/load and active rules package sync so Lodestar cannot remain active without Delve.
- Adds info tooltips on the affected expansion rows explaining the dependency behavior.

## Validation

- `npx tsc --noEmit`
- `npx eslint . --quiet`