### PR TITLE
Add Cloudflare PostHog source map publishing

### DIFF
--- a/docs/POSTHOG_SOURCE_MAPS.md
+++ b/docs/POSTHOG_SOURCE_MAPS.md
@@ -1,0 +1,73 @@
+# PostHog source maps for Cloudflare Pages
+
+This repo uploads PostHog source maps from the Cloudflare Pages build, not from GitHub Actions.
+
+The build flow is:
+
+1. Vite builds the frontend into `dist/` with source maps enabled.
+2. On Cloudflare production builds only (`CF_PAGES_BRANCH=main`), the build script injects PostHog metadata into `dist/`.
+3. The same script uploads the source maps to PostHog and deletes the local `.map` files after upload.
+4. Cloudflare deploys the injected files from `dist/`.
+
+## What to change and where
+
+1. In PostHog, create or confirm the project you want to receive the source maps.
+
+2. In PostHog, create a personal API key with the error tracking write and organization read scopes.
+
+3. In Cloudflare Pages, add these production-only environment variables:
+
+   - `POSTHOG_CLI_PROJECT_ID`
+   - `POSTHOG_CLI_API_KEY`
+   - `POSTHOG_CLI_HOST` if you are not using the default PostHog region
+
+4. Set the Cloudflare build command to:
+
+   ```bash
+   npm run build:cloudflare
+   ```
+
+5. Leave GitHub Actions as-is. The existing workflows remain Supabase-only and do not upload PostHog assets.
+
+## Repository changes that support this
+
+- `vite.config.ts` enables `build.sourcemap: true` so `dist/` includes the maps Cloudflare needs to upload.
+- `scripts/build-cloudflare.sh` runs the build, skips PostHog on non-`main` branches, and uploads on `main`.
+- `package.json` includes `build:cloudflare` as a local shortcut for the same script.
+
+## Main-only behavior
+
+The script checks `CF_PAGES_BRANCH` after the build finishes:
+
+- if the branch is not `main`, it exits successfully without touching PostHog
+- if the branch is `main`, it requires:
+
+  - `CF_PAGES_COMMIT_SHA`
+  - `POSTHOG_CLI_PROJECT_ID`
+  - `POSTHOG_CLI_API_KEY`
+
+  and then runs:
+
+  ```bash
+  ./node_modules/.bin/posthog-cli sourcemap inject --directory dist
+  ./node_modules/.bin/posthog-cli sourcemap upload --directory dist --release-name iron-link-web --release-version "$CF_PAGES_COMMIT_SHA" --delete-after
+  ```
+
+## Verification
+
+After a production deploy, check two things:
+
+1. In PostHog, confirm the new symbol set/source map upload exists for the release version that matches `CF_PAGES_COMMIT_SHA`.
+2. In the deployed JavaScript, confirm the injected `//# chunkId=...` metadata is present.
+
+If those two checks pass, PostHog can match runtime errors back to the uploaded source maps.
+
+## Rollback
+
+If you need to disable source map publishing, the smallest rollback is:
+
+1. remove the Cloudflare production-only `POSTHOG_CLI_*` variables
+2. change the Cloudflare build command back to the plain frontend build
+3. redeploy
+
+If you want to fully undo the code change, revert the `vite.config.ts`, `package.json`, and `scripts/build-cloudflare.sh` changes together.

--- a/docs/POSTHOG_SOURCE_MAPS.md
+++ b/docs/POSTHOG_SOURCE_MAPS.md
@@ -13,7 +13,7 @@ The build flow is:
 
 1. In PostHog, create or confirm the project you want to receive the source maps.
 
-2. In PostHog, create a personal API key with the error tracking write and organization read scopes.
+2. In PostHog, create a personal API key scoped to this project with the `error_tracking:write` scope. The pinned PostHog CLI requires this scope for source-map uploads; no organization-level scope is needed.
 
 3. In Cloudflare Pages, add these production-only environment variables:
 

--- a/docs/POSTHOG_SOURCE_MAPS.md
+++ b/docs/POSTHOG_SOURCE_MAPS.md
@@ -4,7 +4,7 @@ This repo uploads PostHog source maps from the Cloudflare Pages build, not from 
 
 The build flow is:
 
-1. Vite builds the frontend into `dist/` with source maps enabled.
+1. Vite builds the frontend into `dist/`, enabling source maps only for Cloudflare's `main` build.
 2. On Cloudflare production builds only (`CF_PAGES_BRANCH=main`), the build script injects PostHog metadata into `dist/`.
 3. The same script uploads the source maps to PostHog and deletes the local `.map` files after upload.
 4. Cloudflare deploys the injected files from `dist/`.
@@ -31,7 +31,7 @@ The build flow is:
 
 ## Repository changes that support this
 
-- `vite.config.ts` enables `build.sourcemap: true` so `dist/` includes the maps Cloudflare needs to upload.
+- `vite.config.ts` enables `build.sourcemap` only when Cloudflare is building `main`, so preview deployments do not publish `.map` files.
 - `scripts/build-cloudflare.sh` runs the build, skips PostHog on non-`main` branches, and uploads on `main`.
 - `package.json` includes `build:cloudflare` as a local shortcut for the same script.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@posthog/cli": "^0.8.4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -2471,6 +2472,51 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@posthog/cli": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@posthog/cli/-/cli-0.8.4.tgz",
+      "integrity": "sha512-NLoLF6j+dcnBrbTUOYPUaOR4hj+bniXEyPJ3loDu3/HAOZo0nLasVd6Y+YiM4BTynrygvHT+KZUNZpRVLHzxoQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "posthog-cli": "run-posthog-cli.js"
+      },
+      "engines": {
+        "node": ">=14.14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@posthog/cli/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@remirror/core-constants": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "tsc": "tsc -b",
     "build": "npm run tsc && vitest --run && vite build",
+    "build:cloudflare": "bash scripts/build-cloudflare.sh",
     "lint": "eslint .",
     "format": "eslint . --fix && prettier . --write",
     "preview": "vite preview",
@@ -73,6 +74,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@posthog/cli": "^0.8.4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/scripts/build-cloudflare.sh
+++ b/scripts/build-cloudflare.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POSTHOG_CLI_BIN="${ROOT_DIR}/node_modules/.bin/posthog-cli"
+
+cd "${ROOT_DIR}"
+
+echo "Running frontend build..."
+npm run build
+
+if [[ "${CF_PAGES_BRANCH:-}" != "main" ]]; then
+  echo "Skipping PostHog source map upload on branch '${CF_PAGES_BRANCH:-<unset>}'"
+  exit 0
+fi
+
+require_env() {
+  local name="$1"
+  local value="${!name:-}"
+
+  if [[ -z "${value}" ]]; then
+    echo "Missing required environment variable '${name}' for the Cloudflare main build." >&2
+    exit 1
+  fi
+}
+
+require_env CF_PAGES_COMMIT_SHA
+require_env POSTHOG_CLI_PROJECT_ID
+require_env POSTHOG_CLI_API_KEY
+
+if [[ ! -x "${POSTHOG_CLI_BIN}" ]]; then
+  echo "PostHog CLI is not installed at ${POSTHOG_CLI_BIN}. Run npm ci so @posthog/cli is available." >&2
+  exit 1
+fi
+
+echo "Injecting PostHog source map metadata into dist..."
+"${POSTHOG_CLI_BIN}" sourcemap inject --directory dist
+
+echo "Uploading PostHog source maps for iron-link-web at ${CF_PAGES_COMMIT_SHA}..."
+upload_args=(
+  sourcemap upload
+  --directory dist
+  --release-name iron-link-web
+  --release-version "${CF_PAGES_COMMIT_SHA}"
+  --delete-after
+)
+
+if [[ -n "${POSTHOG_CLI_HOST:-}" ]]; then
+  upload_args+=(--host "${POSTHOG_CLI_HOST}")
+fi
+
+POSTHOG_CLI_PROJECT_ID="${POSTHOG_CLI_PROJECT_ID}" \
+POSTHOG_CLI_API_KEY="${POSTHOG_CLI_API_KEY}" \
+"${POSTHOG_CLI_BIN}" "${upload_args[@]}"

--- a/scripts/build-cloudflare.sh
+++ b/scripts/build-cloudflare.sh
@@ -38,6 +38,12 @@ echo "Injecting PostHog source map metadata into dist..."
 "${POSTHOG_CLI_BIN}" sourcemap inject --directory dist
 
 echo "Uploading PostHog source maps for iron-link-web at ${CF_PAGES_COMMIT_SHA}..."
+cli_args=()
+
+if [[ -n "${POSTHOG_CLI_HOST:-}" ]]; then
+  cli_args+=(--host "${POSTHOG_CLI_HOST}")
+fi
+
 upload_args=(
   sourcemap upload
   --directory dist
@@ -46,10 +52,6 @@ upload_args=(
   --delete-after
 )
 
-if [[ -n "${POSTHOG_CLI_HOST:-}" ]]; then
-  upload_args+=(--host "${POSTHOG_CLI_HOST}")
-fi
-
 POSTHOG_CLI_PROJECT_ID="${POSTHOG_CLI_PROJECT_ID}" \
 POSTHOG_CLI_API_KEY="${POSTHOG_CLI_API_KEY}" \
-"${POSTHOG_CLI_BIN}" "${upload_args[@]}"
+"${POSTHOG_CLI_BIN}" "${cli_args[@]}" "${upload_args[@]}"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,12 @@ import { defineConfig } from "vite";
 import svgr from "vite-plugin-svgr";
 import tsConfigPaths from "vite-tsconfig-paths";
 
+const isCloudflareProductionBuild = process.env.CF_PAGES_BRANCH === "main";
+
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
-    sourcemap: true,
+    sourcemap: isCloudflareProductionBuild,
   },
   plugins: [react(), svgr(), tsConfigPaths()],
   define: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,9 @@ import tsConfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    sourcemap: true,
+  },
   plugins: [react(), svgr(), tsConfigPaths()],
   define: {
     APP_VERSION: JSON.stringify(process.env.npm_package_version),


### PR DESCRIPTION
## What changed

- Enable Vite source maps only for Cloudflare's `main` build.
- Add the reproducible `@posthog/cli` dependency.
- Add `npm run build:cloudflare`, which:
  - builds the frontend
  - skips PostHog on preview branches
  - injects and uploads source maps on `main`
  - uses `iron-link-web` plus `CF_PAGES_COMMIT_SHA` for release identity
  - deletes local source maps after upload
- Document the setup order in `docs/POSTHOG_SOURCE_MAPS.md`.

GitHub Actions remains Supabase-only; the source-map flow runs where the Cloudflare Pages build runs.

## Cloudflare setup order

1. Create/confirm the PostHog project and a personal API key scoped to that project with the `error_tracking:write` scope.
2. Add these as Cloudflare Pages Production environment variables:
   - `POSTHOG_CLI_PROJECT_ID`
   - `POSTHOG_CLI_API_KEY`
   - optional `POSTHOG_CLI_HOST`
3. Set the Cloudflare Pages build command to `npm run build:cloudflare`.
4. Keep the output directory as `dist`.
5. Deploy `main`, then confirm the release/symbol set in PostHog and the injected `chunkId` metadata in the deployed JavaScript.

## Validation

- `npm ci`
- `CF_PAGES_BRANCH=preview ... npm run build:cloudflare` — passed; no source maps are produced or uploaded.
- `CF_PAGES_BRANCH=main ... npm run build` — passed; source maps are produced.
- Main-build credential guard — passed; fails clearly when PostHog credentials are missing.
- `npm run tsc` — passed.
- `npm run lint` — passed with one existing Fast Refresh warning in `src/components/characters/PortraitAvatar/PortraitAvatarDisplay.tsx`.
- Fresh verifier review — passed.
